### PR TITLE
Removed resourceId argument from ResourceAttribute endpoints

### DIFF
--- a/src/Chronos.MainApi/Resources/Controllers/ResourceController.cs
+++ b/src/Chronos.MainApi/Resources/Controllers/ResourceController.cs
@@ -174,7 +174,7 @@ public class ResourceController(
     
     [Authorize(Policy = "OrgRole:ResourceManager")]
     [HttpPost("attributes")]
-    public async Task<IActionResult> CreateResourceAttributeAsync(Guid resourceId, [FromBody] CreateResourceAttributeRequest request)
+    public async Task<IActionResult> CreateResourceAttributeAsync([FromBody] CreateResourceAttributeRequest request)
     {
         logger.LogInformation("Create resource attribute endpoint was called.");
         var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
@@ -186,7 +186,7 @@ public class ResourceController(
         
         var response = resourceAttribute.ToResourceAttributeResponse();
         
-        return CreatedAtAction(nameof(GetResourceAttribute), new { resourceId, resourceAttributeId = resourceAttribute.Id }, response);
+        return CreatedAtAction(nameof(GetResourceAttribute), new { resourceAttributeId = resourceAttribute.Id }, response);
     }
     
     [Authorize(Policy = "OrgRole:Viewer")]
@@ -221,7 +221,7 @@ public class ResourceController(
     
     [Authorize(Policy = "OrgRole:ResourceManager")]
     [HttpPatch("attributes/{resourceAttributeId}")]
-    public async Task<IActionResult> UpdateResourceAttributeAsync(Guid resourceId, Guid resourceAttributeId, [FromBody] UpdateResourceAttributeRequest request)
+    public async Task<IActionResult> UpdateResourceAttributeAsync(Guid resourceAttributeId, [FromBody] UpdateResourceAttributeRequest request)
     {
         logger.LogInformation("Update resource attribute endpoint was called for resource attribute {ResourceAttributeId}", resourceAttributeId);
         var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
@@ -237,7 +237,7 @@ public class ResourceController(
     
     [Authorize(Policy = "OrgRole:ResourceManager")]
     [HttpDelete("attributes/{resourceAttributeId}")]
-    public async Task<IActionResult> DeleteResourceAttributeAsync(Guid resourceId, Guid resourceAttributeId)
+    public async Task<IActionResult> DeleteResourceAttributeAsync(Guid resourceAttributeId)
     {
         logger.LogInformation("Delete resource attribute endpoint was called for resource attribute {ResourceAttributeId}", resourceAttributeId);
         var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);


### PR DESCRIPTION
## Description

Removed problematic resourceId argument in ResourceAttribute endpoints

## Related Issues

#126 

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

-   [ ] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [ ] Manual testing completed
-   [ ] All existing tests pass

## Checklist

<!-- Mark completed items with an "x" -->

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings or errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published

## Database Changes

<!-- If applicable, describe any database schema or migration changes -->

-   [x] No database changes
-   [ ] Database migration included
-   [ ] Database migration instructions provided below


## Configuration Changes

<!-- If applicable, describe any configuration changes needed -->

-   [x] No configuration changes required
-   [ ] Configuration changes documented below

