### PR TITLE
Added duration field to Activity and create/update endpoints

### DIFF
--- a/src/Chronos.Domain/Resources/Activity.cs
+++ b/src/Chronos.Domain/Resources/Activity.cs
@@ -7,4 +7,5 @@ public class Activity : ObjectInformation
     public Guid AssignedUserId { get; set; }
     public required string ActivityType { get; set; }
     public int? ExpectedStudents { get; set; }
+    public int Duration { get; set; }
 }

--- a/src/Chronos.MainApi/Resources/Contracts/ActivityResponse.cs
+++ b/src/Chronos.MainApi/Resources/Contracts/ActivityResponse.cs
@@ -6,4 +6,5 @@ public sealed record ActivityResponse(
     Guid SubjectId,
     Guid AssignedUserId,
     string ActivityType,
-    int? ExpectedStudents);
+    int? ExpectedStudents,
+    int Duration);

--- a/src/Chronos.MainApi/Resources/Contracts/CreateActivityRequest.cs
+++ b/src/Chronos.MainApi/Resources/Contracts/CreateActivityRequest.cs
@@ -6,4 +6,5 @@ public sealed record CreateActivityRequest(
     Guid SubjectId,
     Guid AssignedUserId,
     string ActivityType,
-    int? ExpectedStudents);
+    int? ExpectedStudents,
+    int Duration);

--- a/src/Chronos.MainApi/Resources/Contracts/UpdateActivityRequest.cs
+++ b/src/Chronos.MainApi/Resources/Contracts/UpdateActivityRequest.cs
@@ -5,4 +5,5 @@ public sealed record UpdateActivityRequest(
     Guid SubjectId,
     Guid AssignedUserId,
     string ActivityType,
-    int? ExpectedStudents);
+    int? ExpectedStudents,
+    int Duration);

--- a/src/Chronos.MainApi/Resources/Controllers/SubjectController.cs
+++ b/src/Chronos.MainApi/Resources/Controllers/SubjectController.cs
@@ -105,7 +105,8 @@ public class SubjectController(
             request.SubjectId,
             request.AssignedUserId,
             request.ActivityType,
-            request.ExpectedStudents);
+            request.ExpectedStudents,
+            request.Duration);
         
         var response = activity.ToActivityResponse();
         
@@ -173,7 +174,8 @@ public class SubjectController(
             request.SubjectId,
             request.AssignedUserId,
             request.ActivityType,
-            request.ExpectedStudents);
+            request.ExpectedStudents,
+            request.Duration);
         
         return NoContent();
     }

--- a/src/Chronos.MainApi/Resources/Extensions/ActivityMapper.cs
+++ b/src/Chronos.MainApi/Resources/Extensions/ActivityMapper.cs
@@ -12,7 +12,8 @@ public static class ActivityMapper
             SubjectId: activity.SubjectId,
             AssignedUserId: activity.AssignedUserId,
             ActivityType: activity.ActivityType,
-            ExpectedStudents: activity.ExpectedStudents
+            ExpectedStudents: activity.ExpectedStudents,
+            Duration: activity.Duration
         );
 }
 

--- a/src/Chronos.MainApi/Resources/Services/ActivityService.cs
+++ b/src/Chronos.MainApi/Resources/Services/ActivityService.cs
@@ -9,20 +9,27 @@ public class ActivityService(
     ILogger<ActivityService> logger) : IActivityService
 {
     public async Task<Activity> CreateActivityAsync(Guid organizationId, Guid subjectId, Guid assignedUserId, string activityType,
-        int? expectedStudents)
+        int? expectedStudents, int duration)
     {
         logger.LogInformation("Creating activity. OrganizationId: {OrganizationId}, SubjectId: {SubjectId}, AssignedUserId: {AssignedUserId}, ActivityType: {ActivityType}, ExpectedStudents: {ExpectedStudents}",
             organizationId, subjectId, assignedUserId, activityType, expectedStudents);
+        
+        if(duration <= 0)
+        {
+            logger.LogWarning("Invalid activity duration. Duration must be greater than zero. OrganizationId: {OrganizationId}, Duration: {Duration}", organizationId, duration);
+            throw new ArgumentException("Duration must be greater than zero.", nameof(duration));
+        }
 
         await validationService.ValidationOrganizationAsync(organizationId);
-
+        
         var activity = new Activity
         {
             OrganizationId = organizationId,
             SubjectId = subjectId,
             AssignedUserId = assignedUserId,
             ActivityType = activityType,
-            ExpectedStudents = expectedStudents
+            ExpectedStudents = expectedStudents,
+            Duration = duration
         };
 
         await activityRepository.AddAsync(activity);
@@ -71,10 +78,16 @@ public class ActivityService(
     }
 
     public async Task UpdateActivityAsync(Guid organizationId, Guid activityId, Guid subjectId, Guid assignedUserId, string activityType,
-        int? expectedStudents)
+        int? expectedStudents, int duration)
     {
         logger.LogInformation("Updating activity. OrganizationId: {OrganizationId}, ActivityId: {ActivityId}, SubjectId: {SubjectId}, AssignedUserId: {AssignedUserId}, ActivityType: {ActivityType}, ExpectedStudents: {ExpectedStudents}",
             organizationId, activityId, subjectId, assignedUserId, activityType, expectedStudents);
+
+        if (duration <= 0)
+        {
+            logger.LogWarning("Invalid activity duration. Duration must be greater than zero. OrganizationId: {OrganizationId}, ActivityId: {ActivityId}, Duration: {Duration}", organizationId, activityId, duration);
+            throw new ArgumentException("Duration must be greater than zero.", nameof(duration));
+        }
 
         await validationService.ValidationOrganizationAsync(organizationId);
         var activity = await validationService.ValidateAndGetActivityAsync(organizationId,  activityId);
@@ -83,6 +96,7 @@ public class ActivityService(
         activity.AssignedUserId = assignedUserId;
         activity.ActivityType = activityType;
         activity.ExpectedStudents = expectedStudents;
+        activity.Duration = duration;
         await activityRepository.UpdateAsync(activity);
 
         logger.LogInformation("Activity updated successfully. ActivityId: {ActivityId}", activityId);

--- a/src/Chronos.MainApi/Resources/Services/IActivityService.cs
+++ b/src/Chronos.MainApi/Resources/Services/IActivityService.cs
@@ -4,10 +4,10 @@ namespace Chronos.MainApi.Resources.Services;
 
 public interface IActivityService
 {
-    Task<Activity> CreateActivityAsync(Guid organizationId, Guid subjectId, Guid assignedUserId, string activityType, int? expectedStudents);
+    Task<Activity> CreateActivityAsync(Guid organizationId, Guid subjectId, Guid assignedUserId, string activityType, int? expectedStudents, int duration);
     Task<Activity> GetActivityAsync(Guid organizationId, Guid activityId);
     Task<List<Activity>> GetActivitiesAsync(Guid organizationId);
     Task<List<Activity>> GetActivitiesBySubjectAsync(Guid organizationId, Guid subjectId);
-    Task UpdateActivityAsync(Guid organizationId, Guid activityId, Guid subjectId, Guid assignedUserId, string activityType, int? expectedStudents);
+    Task UpdateActivityAsync(Guid organizationId, Guid activityId, Guid subjectId, Guid assignedUserId, string activityType, int? expectedStudents, int duration);
     Task DeleteActivityAsync(Guid organizationId, Guid activityId);
 }


### PR DESCRIPTION
## Description

Added new field to Activity entity - duration. Each course needs a duration so that the engine would assign it exactly this number of hours.

## Related Issues

Closes bgu-nasa/main#44

## Changes Made

<!-- List the main changes made in this PR -->

- Added Duration in Activity Domain entity
- Modified Activity service create and update methods to get also duration param
- Modified requests/response objects and the activity mapper to contain duration
- Modified create/update activity endpoints in SubjectController to use the duration field

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

-   [ ] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [ ] Manual testing completed
-   [ ] All existing tests pass

## Checklist

<!-- Mark completed items with an "x" -->

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings or errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published

## Database Changes

<!-- If applicable, describe any database schema or migration changes -->

-   [x] No database changes
-   [ ] Database migration included
-   [ ] Database migration instructions provided below

<!-- If migrations are needed, provide instructions -->

## Configuration Changes

<!-- If applicable, describe any configuration changes needed -->

-   [x] No configuration changes required
-   [ ] Configuration changes documented below
