### PR TITLE
[Schedule] Add WeekNum persistence to Assignment schema and model

### DIFF
--- a/src/Chronos.Data/Migrations/20260412090944_AddWeekNumToAssignments.Designer.cs
+++ b/src/Chronos.Data/Migrations/20260412090944_AddWeekNumToAssignments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Chronos.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Chronos.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412090944_AddWeekNumToAssignments")]
+    partial class AddWeekNumToAssignments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Chronos.Data/Migrations/20260412090944_AddWeekNumToAssignments.cs
+++ b/src/Chronos.Data/Migrations/20260412090944_AddWeekNumToAssignments.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Chronos.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWeekNumToAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("ALTER TABLE \"assignments\" ADD COLUMN IF NOT EXISTS \"WeekNum\" integer NULL;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_assignments_SlotId_ResourceId\";");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_assignments_SlotId_ResourceId_WeekYear_WeekNum\";");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_assignments_SlotId_ResourceId_WeekNum\";");
+            migrationBuilder.Sql("ALTER TABLE \"assignments\" DROP COLUMN IF EXISTS \"WeekYear\";");
+            migrationBuilder.Sql("CREATE UNIQUE INDEX IF NOT EXISTS \"IX_assignments_SlotId_ResourceId_WeekNum\" ON \"assignments\" (\"SlotId\", \"ResourceId\", \"WeekNum\");");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_assignments_SlotId_ResourceId_WeekNum\";");
+            migrationBuilder.Sql("ALTER TABLE \"assignments\" ADD COLUMN IF NOT EXISTS \"WeekYear\" integer NULL;");
+            migrationBuilder.Sql("CREATE UNIQUE INDEX IF NOT EXISTS \"IX_assignments_SlotId_ResourceId_WeekYear_WeekNum\" ON \"assignments\" (\"SlotId\", \"ResourceId\", \"WeekYear\", \"WeekNum\");");
+        }
+    }
+}

--- a/src/Chronos.Data/ModelConfig/Schedule/AssignmentConfiguration.cs
+++ b/src/Chronos.Data/ModelConfig/Schedule/AssignmentConfiguration.cs
@@ -22,7 +22,10 @@ public class AssignmentConfiguration : IEntityTypeConfiguration<Assignment>
         builder.Property(a => a.ActivityId)
             .IsRequired();
 
-        builder.HasIndex(a => new { a.SlotId, a.ResourceId })
+        builder.Property(a => a.WeekNum)
+            .IsRequired(false);
+
+        builder.HasIndex(a => new { a.SlotId, a.ResourceId, a.WeekNum })
             .IsUnique();
     }
 }

--- a/src/Chronos.Domain/Schedule/Assignment.cs
+++ b/src/Chronos.Domain/Schedule/Assignment.cs
@@ -7,4 +7,5 @@ public class Assignment : ObjectInformation
     public Guid SlotId { get; set; }
     public Guid ResourceId { get; set; }
     public Guid ActivityId { get; set; }
+    public int? WeekNum { get; set; }
 }


### PR DESCRIPTION
## Description
Adds `WeekNum` to Assignment domain model and database schema, and updates assignment unique index to include `WeekNum`.

## Related Issues
Fixes #197 

## Changes Made
- Added `WeekNum` property to Assignment
- Updated Assignment EF configuration to include `WeekNum` and new unique index
- Added migration and snapshot updates for `WeekNum`/index changes

## Testing
-   [ ] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [x] Manual testing completed
-   [x] All existing tests pass

### Test Instructions
1. Apply migrations
2. Confirm assignments table has `WeekNum` column
3. Confirm unique index is `SlotId` + `ResourceId` + `WeekNum`

## Checklist
-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings or errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published

## Database Changes
-   [ ] No database changes
-   [x] Database migration included
-   [x] Database migration instructions provided below

Run migrations before deploying app services that rely on `WeekNum`.

## Configuration Changes
-   [x] No configuration changes required
-   [ ] Configuration changes documented below

## Deployment Notes
Apply migration before engine rollouts that write `WeekNum`.

## Additional Context
