### PR TITLE
Thread WeekNum through assignment contracts, services, and repository

### DIFF
--- a/src/Chronos.Data/Repositories/Schedule/AssignmentRepository.cs
+++ b/src/Chronos.Data/Repositories/Schedule/AssignmentRepository.cs
@@ -47,6 +47,12 @@ public class AssignmentRepository(AppDbContext context) : IAssignmentRepository
                     .ToListAsync();
                 q = q.Where(a => activityIds.Contains(a.ActivityId));
             }
+
+            if (query.WeekNum.HasValue)
+            {
+                q = q.Where(a => a.WeekNum == query.WeekNum.Value);
+            }
+
         }
 
         return await q.ToListAsync();
@@ -66,10 +72,17 @@ public class AssignmentRepository(AppDbContext context) : IAssignmentRepository
             .ToListAsync();
     }
     
-    public async Task<Assignment?> GetBySlotIdAndResourceIdAsync(Guid slotId, Guid resourceId)
+    public async Task<Assignment?> GetBySlotIdAndResourceIdAsync(Guid slotId, Guid resourceId, int? weekNum = null)
     {
-        return await context.Assignments
-            .FirstOrDefaultAsync(a => a.SlotId == slotId && a.ResourceId == resourceId);
+        var query = context.Assignments
+            .Where(a => a.SlotId == slotId && a.ResourceId == resourceId);
+
+        if (weekNum.HasValue)
+        {
+            query = query.Where(a => a.WeekNum == weekNum.Value);
+        }
+
+        return await query.FirstOrDefaultAsync();
     }
     public async Task<List<Assignment>> GetByResourceIdAsync(Guid resourceId)
     {

--- a/src/Chronos.Data/Repositories/Schedule/IAssignmentRepository.cs
+++ b/src/Chronos.Data/Repositories/Schedule/IAssignmentRepository.cs
@@ -10,7 +10,7 @@ public interface IAssignmentRepository
 
     Task<List<Assignment>> GetBySlotIdAsync(Guid slotId);
     Task<List<Assignment>> GetByActivityIdAsync(Guid activityId);
-    Task<Assignment?> GetBySlotIdAndResourceIdAsync(Guid slotId, Guid resourceId);
+    Task<Assignment?> GetBySlotIdAndResourceIdAsync(Guid slotId, Guid resourceId, int? weekNum = null);
 
     Task<List<Assignment>> GetByResourceIdAsync(Guid resourceId);
     Task<List<Assignment>> GetBySchedulingPeriodIdAsync(Guid schedulingPeriodId);

--- a/src/Chronos.Domain/Schedule/AssignmentQuery.cs
+++ b/src/Chronos.Domain/Schedule/AssignmentQuery.cs
@@ -8,4 +8,5 @@ public class AssignmentQuery
     public Guid? ActivityId { get; set; }
     public Guid? SchedulingPeriodId { get; set; }
     public Guid? UserId { get; set; }
+    public int? WeekNum { get; set; }
 }

--- a/src/Chronos.MainApi/Schedule/Contracts/AssignmentResponse.cs
+++ b/src/Chronos.MainApi/Schedule/Contracts/AssignmentResponse.cs
@@ -5,4 +5,5 @@ public record AssignmentResponse(
     string OrganizationId,
     string SlotId,
     string ResourceId,
-    string ActivityId);
+    string ActivityId,
+    int? WeekNum);

--- a/src/Chronos.MainApi/Schedule/Contracts/CreateAssignmentRequest.cs
+++ b/src/Chronos.MainApi/Schedule/Contracts/CreateAssignmentRequest.cs
@@ -3,4 +3,5 @@ namespace Chronos.MainApi.Schedule.Contracts;
 public record CreateAssignmentRequest(
     Guid SlotId,
     Guid ResourceId,
-    Guid ActivityId);
+    Guid ActivityId,
+    int? WeekNum = null);

--- a/src/Chronos.MainApi/Schedule/Contracts/UpdateAssignmentRequest.cs
+++ b/src/Chronos.MainApi/Schedule/Contracts/UpdateAssignmentRequest.cs
@@ -3,4 +3,5 @@ namespace Chronos.MainApi.Schedule.Contracts;
 public record UpdateAssignmentRequest(
     Guid SlotId,
     Guid ResourceId,
-    Guid ActivityId);
+    Guid ActivityId,
+    int? WeekNum = null);

--- a/src/Chronos.MainApi/Schedule/Controllers/ScheduleController.cs
+++ b/src/Chronos.MainApi/Schedule/Controllers/ScheduleController.cs
@@ -202,7 +202,8 @@ public class ScheduleController(
             organizationId,
             request.SlotId,
             request.ResourceId,
-            request.ActivityId);
+            request.ActivityId,
+            request.WeekNum);
 
         var assignment = await assignmentService.GetAssignmentAsync(organizationId, assignmentId);
         var response = assignment.ToAssignmentResponse();
@@ -294,7 +295,8 @@ public class ScheduleController(
             assignmentId,
             request.SlotId,
             request.ResourceId,
-            request.ActivityId);
+            request.ActivityId,
+            request.WeekNum);
 
         return NoContent();
     }

--- a/src/Chronos.MainApi/Schedule/Extensions/AssignmentMapper.cs
+++ b/src/Chronos.MainApi/Schedule/Extensions/AssignmentMapper.cs
@@ -11,6 +11,7 @@ public static class AssignmentMapper
             OrganizationId: assignment.OrganizationId.ToString(),
             SlotId: assignment.SlotId.ToString(),
             ResourceId: assignment.ResourceId.ToString(),
-            ActivityId: assignment.ActivityId.ToString()
+            ActivityId: assignment.ActivityId.ToString(),
+            WeekNum: assignment.WeekNum
         );
 }

--- a/src/Chronos.MainApi/Schedule/Services/AssignmentService.cs
+++ b/src/Chronos.MainApi/Schedule/Services/AssignmentService.cs
@@ -15,7 +15,7 @@ public class AssignmentService(
     ISchedulingPeriodService schedulingPeriodService,
     ILogger<AssignmentService> logger) : IAssignmentService
 {
-    public async Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid activityId)
+    public async Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid activityId, int? weekNum = null)
     {
         logger.LogInformation(
             "Creating assignment. OrganizationId: {OrganizationId}, SlotId: {SlotId}, ResourceId: {ResourceId}, ActivityId: {ActivityId}",
@@ -23,7 +23,7 @@ public class AssignmentService(
         
         await validationService.ValidateOrganizationAsync(organizationId);
         await ValidateDataAsync(organizationId, slotId, resourceId, activityId);
-        await validateTwoAssignmentsPerSlotPerResourceAsync(organizationId, slotId, resourceId);
+        await ValidateNoConflictingAssignmentAsync(organizationId, slotId, resourceId, weekNum);
         var assignment = new Assignment
         {
             Id = Guid.NewGuid(),
@@ -31,6 +31,7 @@ public class AssignmentService(
             SlotId = slotId,
             ResourceId = resourceId,
             ActivityId = activityId,
+            WeekNum = weekNum,
         };
         
         await assignmentRepository.AddAsync(assignment);
@@ -138,7 +139,7 @@ public class AssignmentService(
         return assignment;
     }
     
-    public async Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId, Guid activityId)
+    public async Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId, Guid activityId, int? weekNum = null)
     {
         logger.LogInformation(
             "Updating assignment. OrganizationId: {OrganizationId}, AssignmentId: {AssignmentId}",
@@ -146,10 +147,11 @@ public class AssignmentService(
         
         var assignment = await ValidateAndGetAssignmentAsync(organizationId, assignmentId);
         await ValidateDataAsync(organizationId, slotId, resourceId, activityId);
-        await validateTwoAssignmentsPerSlotPerResourceAsync(organizationId, slotId, resourceId , assignmentId);
+        await ValidateNoConflictingAssignmentAsync(organizationId, slotId, resourceId, weekNum, assignmentId);
         assignment.SlotId = slotId;
         assignment.ResourceId = resourceId;
         assignment.ActivityId = activityId;
+        assignment.WeekNum = weekNum;
         
         await assignmentRepository.UpdateAsync(assignment);
         
@@ -248,9 +250,14 @@ public class AssignmentService(
             logger.LogInformation("Resource {ResourceId} capacity is less than expected students for Activity {ActivityId}", resourceId, activityId);
             throw new BadRequestException("Resource capacity is less than expected students for the activity");
         }
-
     }
-    private async Task validateTwoAssignmentsPerSlotPerResourceAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid? excludeAssignmentId = null) 
+
+    private async Task ValidateNoConflictingAssignmentAsync(
+        Guid organizationId,
+        Guid slotId,
+        Guid resourceId,
+        int? weekNum,
+        Guid? excludeAssignmentId = null)
     {
         var slot = await slotService.GetSlotAsync(organizationId, slotId);
         if(slot == null)
@@ -258,24 +265,34 @@ public class AssignmentService(
             logger.LogInformation("Slot {SlotId} not found for Organization {OrganizationId}", slotId, organizationId);
             throw new NotFoundException($"Slot with ID {slotId} not found in organization {organizationId}.");
         }
-        var existingAssignment = await assignmentRepository.GetByResourceIdAsync(resourceId);
-        foreach (var assignment in existingAssignment)
+        var existingAssignments = await assignmentRepository.GetByResourceIdAsync(resourceId);
+        foreach (var assignment in existingAssignments)
         {
             if(excludeAssignmentId != null && assignment.Id == excludeAssignmentId)
             {
                 continue;
             }
-            var assignedSlot = await slotService.GetSlotAsync(organizationId, assignment.SlotId);
-            if(assignedSlot.Weekday == slot.Weekday)
+
+            if (weekNum.HasValue && assignment.WeekNum.HasValue && assignment.WeekNum.Value != weekNum.Value)
             {
-                if((slot.FromTime < assignedSlot.ToTime) && (assignedSlot.FromTime < slot.ToTime))
-                {
-                    logger.LogInformation("Resource {ResourceId} already has an assignment in Slot {SlotId} which overlaps with Slot {NewSlotId}", resourceId, assignedSlot.Id, slotId);
-                    throw new BadRequestException("Resource already has an assignment in a slot that overlaps with the new slot");
-                }
+                continue;
             }
-            
+
+            var assignedSlot = await slotService.GetSlotAsync(organizationId, assignment.SlotId);
+            if (assignedSlot == null)
+            {
+                continue;
+            }
+
+            if (assignedSlot.Weekday == slot.Weekday && (slot.FromTime < assignedSlot.ToTime) && (assignedSlot.FromTime < slot.ToTime))
+            {
+                logger.LogInformation(
+                    "Resource {ResourceId} already has an assignment in Slot {SlotId} which overlaps with the new slot {NewSlotId}",
+                    resourceId,
+                    assignedSlot.Id,
+                    slotId);
+                throw new BadRequestException("Resource already has an assignment in a slot that overlaps with the new slot");
+            }
         }
     }
-    
 }

--- a/src/Chronos.MainApi/Schedule/Services/IAssignmentService.cs
+++ b/src/Chronos.MainApi/Schedule/Services/IAssignmentService.cs
@@ -4,7 +4,7 @@ namespace Chronos.MainApi.Schedule.Services;
 
 public interface IAssignmentService
 {
-    Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid ScheduledItemId);
+    Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid ScheduledItemId, int? weekNum = null);
     
     Task<Assignment> GetAssignmentAsync(Guid organizationId, Guid assignmentId);
     
@@ -22,7 +22,7 @@ public interface IAssignmentService
     
     Task<Assignment?> GetAssignmentBySlotAndResourceItemAsync(Guid organizationId, Guid slotId, Guid resourceId);
     
-    Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId , Guid activityId);
+    Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId , Guid activityId, int? weekNum = null);
     
     Task DeleteAssignmentAsync(Guid organizationId, Guid assignmentId);
     Task DeleteAssignmentsBySchedulingPeriodAsync(Guid organizationId, Guid schedulingPeriodId);


### PR DESCRIPTION
## Description
Adds `WeekNum` end-to-end support across assignment contracts, controller, service logic, mapper, and repository query methods.

## Related Issues
Fixes #199 
Relates to #197 

## Changes Made
- Added `WeekNum` to assignment request/response contracts
- Updated assignment service and repository signatures/query filters
- Updated controller and mapper wiring to carry `WeekNum`

## Testing
-   [ ] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [x] Manual testing completed
-   [x] All existing tests pass

### Test Instructions
1. Create assignment with `WeekNum`
2. Retrieve assignments and confirm `WeekNum` is returned
3. Verify overlap checks are scoped correctly when `WeekNum` is provided

## Checklist
-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings or errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published

## Database Changes
-   [x] No database changes
-   [ ] Database migration included
-   [ ] Database migration instructions provided below

## Configuration Changes
-   [x] No configuration changes required
-   [ ] Configuration changes documented below

## Deployment Notes
Deploy after Service PR #198 migration has been applied.

## Additional Context
