### PR TITLE
[Engine] Add week context to engine constraint processor and evaluator

### DIFF
--- a/src/Chronos.Engine/Constraints/ActivityConstraintProcessor.cs
+++ b/src/Chronos.Engine/Constraints/ActivityConstraintProcessor.cs
@@ -24,7 +24,8 @@ public class ActivityConstraintProcessor(
         Guid activityId,
         Guid organizationId,
         Guid? userId = null,
-        Guid? schedulingPeriodId = null
+        Guid? schedulingPeriodId = null,
+        int? weekNum = null
     )
     {
         _logger.LogInformation(
@@ -53,7 +54,8 @@ public class ActivityConstraintProcessor(
                 constraint,
                 organizationId,
                 activityId,
-                schedulingPeriodId
+                schedulingPeriodId,
+                weekNum
             );
 
             excludedSlots.UnionWith(excludedByThisConstraint);
@@ -96,6 +98,7 @@ public class ActivityConstraintProcessor(
                     Id = userConstraint.Id,
                     OrganizationId = userConstraint.OrganizationId,
                     ActivityId = activityId, // Use activityId for context
+                    WeekNum = userConstraint.WeekNum,
                     Key = userConstraint.Key,
                     Value = userConstraint.Value
                 };
@@ -104,7 +107,8 @@ public class ActivityConstraintProcessor(
                     activityConstraint,
                     organizationId,
                     activityId,
-                    schedulingPeriodId
+                    schedulingPeriodId,
+                    weekNum
                 );
 
                 excludedSlots.UnionWith(excludedByThisConstraint);
@@ -124,9 +128,15 @@ public class ActivityConstraintProcessor(
         ActivityConstraint constraint,
         Guid organizationId,
         Guid activityId,
-        Guid? schedulingPeriodId = null
+        Guid? schedulingPeriodId = null,
+        int? weekNum = null
     )
     {
+        if (constraint.WeekNum.HasValue && weekNum.HasValue && constraint.WeekNum.Value != weekNum.Value)
+        {
+            return new HashSet<Guid>();
+        }
+
         // Try to find a handler for this constraint type
         var handler = _handlers.FirstOrDefault(h => h.ConstraintKey == constraint.Key);
 

--- a/src/Chronos.Engine/Constraints/Evaluation/ConstraintEvaluator.cs
+++ b/src/Chronos.Engine/Constraints/Evaluation/ConstraintEvaluator.cs
@@ -24,9 +24,9 @@ public class ConstraintEvaluator : IConstraintEvaluator
     }
 
     /// <inheritdoc />
-    public async Task<bool> CanAssignAsync(Activity activity, Slot slot, Resource resource)
+    public async Task<bool> CanAssignAsync(Activity activity, Slot slot, Resource resource, int? weekNum = null)
     {
-        var violations = await GetViolationsAsync(activity, slot, resource);
+        var violations = await GetViolationsAsync(activity, slot, resource, weekNum);
 
         // Assignment is valid only if there are no hard constraint violations
         var hasHardViolations = violations.Any(v => v.ViolationType == ViolationType.Hard);
@@ -38,7 +38,8 @@ public class ConstraintEvaluator : IConstraintEvaluator
     public async Task<IEnumerable<ConstraintViolation>> GetViolationsAsync(
         Activity activity,
         Slot slot,
-        Resource resource
+        Resource resource,
+        int? weekNum = null
     )
     {
         // Create a scope to resolve scoped dependencies (repository and validators)
@@ -50,6 +51,12 @@ public class ConstraintEvaluator : IConstraintEvaluator
 
         // Load all constraints for this activity
         var constraints = await constraintRepository.GetByActivityIdAsync(activity.Id);
+        if (weekNum.HasValue)
+        {
+            constraints = constraints
+                .Where(constraint => !constraint.WeekNum.HasValue || constraint.WeekNum.Value == weekNum.Value)
+                .ToList();
+        }
 
         _logger.LogInformation(
             "Evaluating {ConstraintCount} constraints for Activity {ActivityId} with Slot {SlotId} and Resource {ResourceId}",

--- a/src/Chronos.Engine/Constraints/Evaluation/IConstraintEvaluator.cs
+++ b/src/Chronos.Engine/Constraints/Evaluation/IConstraintEvaluator.cs
@@ -17,7 +17,7 @@ public interface IConstraintEvaluator
     /// <param name="slot">The time slot</param>
     /// <param name="resource">The resource (e.g., room, equipment)</param>
     /// <returns>True if assignment is valid (no hard constraint violations), false otherwise</returns>
-    Task<bool> CanAssignAsync(Activity activity, Slot slot, Resource resource);
+    Task<bool> CanAssignAsync(Activity activity, Slot slot, Resource resource, int? weekNum = null);
 
     /// <summary>
     /// Gets all constraint violations for the given Activity, Slot, and Resource combination
@@ -29,6 +29,7 @@ public interface IConstraintEvaluator
     Task<IEnumerable<ConstraintViolation>> GetViolationsAsync(
         Activity activity,
         Slot slot,
-        Resource resource
+        Resource resource,
+        int? weekNum = null
     );
 }

--- a/src/Chronos.Engine/Constraints/IConstraintProcessor.cs
+++ b/src/Chronos.Engine/Constraints/IConstraintProcessor.cs
@@ -10,6 +10,7 @@ public interface IConstraintProcessor
         Guid activityId, 
         Guid organizationId,
         Guid? userId = null,
-        Guid? schedulingPeriodId = null
+        Guid? schedulingPeriodId = null,
+        int? weekNum = null
     );
 }


### PR DESCRIPTION
## Description
Introduces optional `weekNum` parameters in engine constraint interfaces and filters constraints by matching `WeekNum`.

## Related Issues
Fixes #201 

## Changes Made
- Added `weekNum` to `IConstraintProcessor` and `IConstraintEvaluator` methods
- Updated `ActivityConstraintProcessor` to filter week-specific constraints
- Updated `ConstraintEvaluator` to evaluate constraints in the target week context

## Testing
-   [ ] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [x] Manual testing completed
-   [x] All existing tests pass

### Test Instructions
1. Create one-time and repeated constraints
2. Evaluate assignment for multiple weeks
3. Confirm only matching week constraints apply

## Checklist
-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings or errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published

## Database Changes
-   [x] No database changes
-   [ ] Database migration included
-   [ ] Database migration instructions provided below

## Configuration Changes
-   [x] No configuration changes required
-   [ ] Configuration changes documented below

## Deployment Notes
Can be deployed independently.

## Additional Context
