### PR TITLE
[Infra] Wire Discord Logger into Engine and Offboarding Microservices

### DIFF
--- a/src/Chronos.Engine/AppSettings/appsettings.json
+++ b/src/Chronos.Engine/AppSettings/appsettings.json
@@ -5,6 +5,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "DiscordLogger": {
+    "DiscordWebhookUrl": ""
+  },
   "RabbitMQ": {
     "HostName": "",
     "Port": 0,

--- a/src/Chronos.Engine/Program.cs
+++ b/src/Chronos.Engine/Program.cs
@@ -9,6 +9,7 @@ using Chronos.Engine.Constraints.Evaluation;
 using Chronos.Engine.Constraints.Evaluation.Validators;
 using Chronos.Engine.Matching;
 using Chronos.Engine.Messaging;
+using Chronos.Shared.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
@@ -24,6 +25,11 @@ builder
         reloadOnChange: true
     )
     .AddEnvironmentVariables();
+
+// Configure Discord Logger
+builder.Services.Configure<DiscordLoggerConfiguration>(
+    builder.Configuration.GetSection("DiscordLogger"));
+builder.Logging.AddDiscordLogger("ChronosEngine");
 
 // Configuration
 builder.Services.Configure<RabbitMqOptions>(

--- a/src/Chronos.Offboarding/AppSettings/appsettings.json
+++ b/src/Chronos.Offboarding/AppSettings/appsettings.json
@@ -5,6 +5,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "DiscordLogger": {
+    "DiscordWebhookUrl": ""
+  },
   "Offboarding": {
     "CronSchedule": "0 2 * * *",
     "RetentionDays": 90

--- a/src/Chronos.Offboarding/Program.cs
+++ b/src/Chronos.Offboarding/Program.cs
@@ -6,10 +6,16 @@ using Chronos.Data.Repositories.Schedule;
 using Chronos.Offboarding;
 using Chronos.Offboarding.Removers;
 using Chronos.Offboarding.Workers;
+using Chronos.Shared.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+// Configure Discord Logger
+builder.Services.Configure<DiscordLoggerConfiguration>(
+    builder.Configuration.GetSection("DiscordLogger"));
+builder.Logging.AddDiscordLogger("ChronosOffboarding");
 
 // Configuration
 builder.Services.Configure<OffboardingConfiguration>(


### PR DESCRIPTION
Adds Discord logging to the **Chronos.Engine** and **Chronos.Offboarding** worker services, matching the existing setup in `Chronos.MainApi`. Both services already had transitive access to the Discord logger through `Chronos.Shared` (via `Chronos.Data`), but never wired it up — they were only logging to the console.

## Changes

### `src/Chronos.Engine/Program.cs`
- Added `using Chronos.Shared.Logging`
- Configured `DiscordLoggerConfiguration` from the `DiscordLogger` config section
- Registered the Discord logger with bot name `"ChronosEngine"`

### `src/Chronos.Offboarding/Program.cs`
- Added `using Chronos.Shared.Logging`
- Configured `DiscordLoggerConfiguration` from the `DiscordLogger` config section
- Registered the Discord logger with bot name `"ChronosOffboarding"`

### `src/Chronos.Engine/AppSettings/appsettings.json`
- Added `DiscordLogger.DiscordWebhookUrl` configuration placeholder

### `src/Chronos.Offboarding/AppSettings/appsettings.json`
- Added `DiscordLogger.DiscordWebhookUrl` configuration placeholder

## Configuration

Both services read the webhook URL from:
- **appsettings.json**: `DiscordLogger:DiscordWebhookUrl`
- **Environment variable**: `DiscordLogger__DiscordWebhookUrl`

If the webhook URL is empty, the logger falls back to console-only logging (no Discord messages are sent), so this is fully backward-compatible.

## Deployment Note

To enable Discord logging for these services in the deployed environment, add `DiscordLogger__DiscordWebhookUrl=<url>` to the `.engine.<CLOUD_ENV>.env` and `.offboarding.<CLOUD_ENV>.env` files in `Chronos.ServiceProxy`.
