### PR TITLE
[Agent][Api] Bootstrap Agent Service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,12 @@ ConnectionStrings__DefaultConnection=
 # Chronos.Engine — RabbitMQ consumer channel open retries (set via env; code defaults 10 / 2000 if omitted)
 RabbitMQ__ConnectionMaxRetries=10
 RabbitMQ__ConnectionInitialDelayMs=2000
+
+# Agent Configuration
+# LLM provider to use: "ollama" (university server) or "puter" (free API for local dev)
+Agent__LlmProvider=ollama
+Agent__Ollama__BaseUrl=
+Agent__Ollama__Model=phi3
+Agent__Puter__BaseUrl=https://api.puter.com
+Agent__Puter__ApiToken=
+Agent__Puter__Model=gpt-4o-mini

--- a/doc/agent-api-uni.md
+++ b/doc/agent-api-uni.md
@@ -7,7 +7,7 @@ Here are some example use cases with a variety of LLM models of the API (you can
 1. Basic Text Generation (/api/generate)
 Used for "one-shot" tasks where you don't need the model to remember previous messages. Ideal for summarization or data extraction.
 Bash
-curl -k https://132.73.84.84/api/generate -d '{
+curl -k https://<OLLAMA_HOST>/api/generate -d '{
  "model": "gpt-oss:20b",
  "prompt": "Summarize the benefits of local LLMs in three bullet points.",
  "stream": false
@@ -15,7 +15,7 @@ curl -k https://132.73.84.84/api/generate -d '{
 2. Conversational Chat (/api/chat)
 Designed for interactive applications. You provide the messages array to maintain context.
 Bash
-curl -k https://132.73.84.84/api/chat -d '{
+curl -k https://<OLLAMA_HOST>/api/chat -d '{
  "model": "llama4",
  "messages": [
    { "role": "user", "content": "What is the capital of France?" },
@@ -27,7 +27,7 @@ curl -k https://132.73.84.84/api/chat -d '{
 3. Structured Data Extraction (JSON Mode)
 Forces the model to output a valid JSON object. This is essential for building apps where the AI's output needs to be parsed by code.
 Bash
-curl -k https://132.73.84.84/api/generate -d '{
+curl -k https://<OLLAMA_HOST>/api/generate -d '{
  "model": "deepseek-v3",
  "prompt": "Extract the name and age from this text: John is a 30-year-old engineer.",
  "format": "json",
@@ -36,7 +36,7 @@ curl -k https://132.73.84.84/api/generate -d '{
 4. Vision & Multimodal Analysis
 If you are running a vision-capable model (like llava or qwen3-omni), you can send an image for analysis. Note that the image must be a base64 encoded string.
 Bash
-curl -k https://132.73.84.84/api/generate -d '{
+curl -k https://<OLLAMA_HOST>/api/generate -d '{
  "model": "llava",
  "prompt": "What is in this image?",
  "images": ["<base64_string_here>"],
@@ -45,11 +45,11 @@ curl -k https://132.73.84.84/api/generate -d '{
 5. Model Inventory
 Retrieve a list of all models currently installed and ready to be played.
 Bash
-curl -k https://132.73.84.84/api/tags
+curl -k https://<OLLAMA_HOST>/api/tags
 6. Model Load Status
 Retrieve a list of all models currently loaded into memory and are and ready for immediate service.
 Bash
-curl -k https://132.73.84.84/api/ps
+curl -k https://<OLLAMA_HOST>/api/ps
 
 Let us know if a specific model, that is not installed, would be needed to be installed.
 

--- a/doc/agent-api.md
+++ b/doc/agent-api.md
@@ -1,0 +1,321 @@
+# Chronos Agent API Documentation
+
+The Chronos Agent provides a conversational interface for submitting scheduling constraints and preferences.
+Users chat naturally (e.g., "I can't work Fridays and prefer mornings"), and the agent extracts structured data,
+presents it for approval, and commits it to the Chronos data layer.
+
+---
+
+## Base URL
+
+```
+/api/agent
+```
+
+All endpoints require **JWT authentication** (Bearer token) and the `x-org-id` header with the user's organization ID.
+
+---
+
+## Authentication
+
+Every request must include:
+
+| Header          | Description                                         |
+|-----------------|-----------------------------------------------------|
+| `Authorization` | `Bearer <JWT token>` — obtained from `/api/auth/login` |
+| `x-org-id`      | Organization UUID — the user's active organization   |
+
+The `userId` is extracted from the JWT claims automatically — clients never send it in request bodies.
+
+---
+
+## Conversation Flow
+
+The agent uses a finite state machine (FSM):
+
+```
+Discovery → Drafting → Submit → Approved (terminal)
+                          ↕
+                       Revision
+```
+
+| State     | Description                                           | Allowed Actions            |
+|-----------|-------------------------------------------------------|----------------------------|
+| Discovery | Free conversation — user describes scheduling needs   | ContinueConversation, RequestSubmit |
+| Drafting  | Transient — agent structures info (no client action)  | —                          |
+| Submit    | Agent presents proposal for review                    | Approve, Revise            |
+| Revision  | User requested changes — back to conversation         | ContinueConversation, RequestSubmit |
+| Approved  | Committed to Chronos — session is done                | (none)                     |
+
+---
+
+## Endpoints
+
+### 1. Start Session
+
+Creates a new conversation session.
+
+```
+POST /api/agent/sessions
+```
+
+**Request Body:**
+
+```json
+{
+  "schedulingPeriodId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+**Response:** `201 Created`
+
+```json
+{
+  "sessionId": "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+}
+```
+
+**Notes:**
+- `schedulingPeriodId` must be a valid scheduling period in the user's organization.
+- Each session is bound to one user, one organization, and one scheduling period.
+
+---
+
+### 2. Send Message
+
+Sends a user message and gets a conversational reply from the LLM.
+
+```
+POST /api/agent/sessions/{sessionId}/messages
+```
+
+**Request Body:**
+
+```json
+{
+  "message": "I can't work on Fridays and I prefer morning shifts"
+}
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "sessionId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "state": "Discovery",
+  "assistantMessage": "Got it! You want to avoid Fridays entirely and prefer morning shifts. Would you like to specify which days you prefer mornings, or is that for all days?",
+  "draft": null,
+  "allowedActions": ["ContinueConversation", "RequestSubmit"]
+}
+```
+
+**Valid states:** Discovery, Revision
+
+---
+
+### 3. Request Submit
+
+Triggers LLM extraction and transitions to Submit state. The agent parses the conversation into structured constraints/preferences.
+
+```
+POST /api/agent/sessions/{sessionId}/submit
+```
+
+**Request Body:** None
+
+**Response:** `200 OK`
+
+```json
+{
+  "sessionId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "state": "Submit",
+  "assistantMessage": null,
+  "draft": {
+    "hardConstraints": [
+      { "key": "avoid_weekday", "value": "Friday" }
+    ],
+    "softPreferences": [
+      { "key": "preferred_time_morning", "value": "true" }
+    ]
+  },
+  "allowedActions": ["Approve", "Revise"]
+}
+```
+
+**Valid states:** Discovery, Revision
+
+---
+
+### 4. Approve
+
+Approves the current draft and submits constraints/preferences to the Chronos data layer.
+
+```
+POST /api/agent/sessions/{sessionId}/approve
+```
+
+**Request Body:** None
+
+**Response:** `200 OK`
+
+```json
+{
+  "sessionId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "state": "Approved",
+  "assistantMessage": null,
+  "draft": { "hardConstraints": [...], "softPreferences": [...] },
+  "allowedActions": []
+}
+```
+
+**What happens on approval:**
+1. FSM transitions to `Approved`
+2. Draft is converted to immutable `ConstraintProposal`
+3. Hard constraints → written as `UserConstraint` records (DB + RabbitMQ event)
+4. Soft preferences → written as `UserPreference` records (DB)
+5. Session becomes terminal (no further actions)
+
+**Valid state:** Submit only
+
+---
+
+### 5. Revise
+
+Returns to Revision state so the user can make changes.
+
+```
+POST /api/agent/sessions/{sessionId}/revise
+```
+
+**Request Body:** None
+
+**Response:** `200 OK`
+
+```json
+{
+  "sessionId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "state": "Revision",
+  "assistantMessage": null,
+  "draft": { "hardConstraints": [...], "softPreferences": [...] },
+  "allowedActions": ["ContinueConversation", "RequestSubmit"]
+}
+```
+
+**Valid state:** Submit only
+
+---
+
+## Error Responses
+
+All errors follow this format:
+
+```json
+{
+  "statusCode": 400,
+  "message": "Cannot transition from Discovery to Approved.",
+  "type": "BadRequest"
+}
+```
+
+| Status | When                                                         |
+|--------|--------------------------------------------------------------|
+| 400    | Invalid state transition (e.g., approve before submit)       |
+| 400    | Constraint extraction failed (malformed LLM response)        |
+| 401    | Missing or invalid JWT token                                 |
+| 401    | Session belongs to a different user/organization             |
+| 404    | Session not found                                            |
+| 500    | LLM provider unreachable or internal error                   |
+
+---
+
+## Known Constraint/Preference Keys
+
+The agent only produces constraints using these validated keys:
+
+### Hard Constraints
+
+| Key               | Value Format | Effect                    |
+|-------------------|--------------|---------------------------|
+| `unavailable_day` | `Friday`     | User cannot be scheduled  |
+| `avoid_weekday`   | `Friday`     | User must avoid this day  |
+
+### Soft Preferences
+
+| Key                        | Value Format                       | Weight |
+|----------------------------|------------------------------------|--------|
+| `preferred_weekday`        | `Monday`                           | 3.0x   |
+| `preferred_weekdays`       | `Monday,Wednesday,Friday`          | 3.0x   |
+| `avoid_weekday`            | `Friday`                           | 0.3x   |
+| `preferred_time_morning`   | `true`                             | 3.0x   |
+| `preferred_time_afternoon` | `true`                             | 2.0x   |
+| `preferred_time_evening`   | `true`                             | 2.0x   |
+| `preferred_timerange`      | `Monday 09:00 - 11:00, ...`       | 4.0x   |
+
+Any key the LLM produces that isn't in this list is silently filtered out.
+
+---
+
+## Configuration
+
+The agent's LLM provider is configured via environment variables or `appsettings.json`:
+
+| Variable                 | Default                    | Description                    |
+|--------------------------|----------------------------|--------------------------------|
+| `Agent__LlmProvider`     | `ollama`                   | `"ollama"` or `"puter"`        |
+| `Agent__Ollama__BaseUrl` | (empty)                    | University Ollama server URL   |
+| `Agent__Ollama__Model`   | `phi3`                     | Model name for Ollama          |
+| `Agent__Puter__BaseUrl`  | `https://api.puter.com`    | Puter API base URL             |
+| `Agent__Puter__ApiToken` | (empty)                    | Bearer token for Puter         |
+| `Agent__Puter__Model`    | `gpt-4o-mini`              | Model name for Puter           |
+
+### LLM Provider Selection
+
+- **Ollama** (default): University Ollama server. Set `Agent__Ollama__BaseUrl` to the server URL. Requires VPN access to the university network. Uses a self-signed certificate (bypassed automatically).
+- **Puter**: Free AI API for local development without VPN. Requires an API token from [puter.com](https://puter.com).
+
+---
+
+## Important Notes
+
+1. **Human-in-the-loop**: The agent never commits changes without explicit user approval (the `approve` endpoint).
+2. **Session isolation**: Each session is bound to one user + org + scheduling period. Cross-user access is denied.
+3. **Stateless sessions (POC)**: Sessions are stored in-memory and lost on service restart. This is acceptable for the POC.
+4. **No contradiction detection**: The agent does not yet detect contradictory constraints (e.g., `preferred_weekday=Friday` + `avoid_weekday=Friday`).
+5. **Downstream effects**: When constraints are approved, existing Chronos infrastructure handles:
+   - DB persistence via EF Core
+   - RabbitMQ event publishing for online scheduling
+   - No additional triggering is needed from the client.
+
+---
+
+## Example: Full Conversation Flow
+
+```bash
+# 1. Start session
+curl -X POST http://localhost:5000/api/agent/sessions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-org-id: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"schedulingPeriodId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}'
+
+# Response: {"sessionId": "11111111-2222-3333-4444-555555555555"}
+
+# 2. Send messages
+curl -X POST http://localhost:5000/api/agent/sessions/11111111-2222-3333-4444-555555555555/messages \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-org-id: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "I cannot work on Fridays and I prefer morning shifts on Monday and Wednesday"}'
+
+# 3. Request submit (extract constraints)
+curl -X POST http://localhost:5000/api/agent/sessions/11111111-2222-3333-4444-555555555555/submit \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-org-id: $ORG_ID"
+
+# 4. Review the draft in the response, then approve
+curl -X POST http://localhost:5000/api/agent/sessions/11111111-2222-3333-4444-555555555555/approve \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-org-id: $ORG_ID"
+
+# Done! Constraints are now in the database.
+```

--- a/src/Chronos.Agent/Configuration/LlmProviderOptions.cs
+++ b/src/Chronos.Agent/Configuration/LlmProviderOptions.cs
@@ -5,7 +5,7 @@ public class OllamaOptions
 {
     public const string SectionName = "Agent:Ollama";
 
-    public string BaseUrl { get; set; } = "https://132.73.84.84";
+    public string BaseUrl { get; set; } = string.Empty;
     public string Model { get; set; } = "llama4";
 }
 

--- a/src/Chronos.Agent/Extraction/ConstraintExtractor.cs
+++ b/src/Chronos.Agent/Extraction/ConstraintExtractor.cs
@@ -56,13 +56,13 @@ public class ConstraintExtractor
         foreach (var c in result.HardConstraints ?? [])
         {
             if (KnownConstraintKeys.IsValid(c.Key))
-                draft.AddHardConstraint(c.Key, c.Value);
+                draft.AddHardConstraint(c.Key, c.ValueAsString);
         }
 
         foreach (var p in result.SoftPreferences ?? [])
         {
             if (KnownConstraintKeys.IsValid(p.Key))
-                draft.AddSoftPreference(p.Key, p.Value);
+                draft.AddSoftPreference(p.Key, p.ValueAsString);
         }
 
         return draft;
@@ -83,7 +83,16 @@ public class ConstraintExtractor
         public string Key { get; set; } = string.Empty;
 
         [JsonPropertyName("value")]
-        public string Value { get; set; } = string.Empty;
+        public JsonElement Value { get; set; }
+
+        public string ValueAsString => Value.ValueKind switch
+        {
+            JsonValueKind.String => Value.GetString() ?? string.Empty,
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Number => Value.GetRawText(),
+            _ => Value.GetRawText()
+        };
     }
 }
 

--- a/src/Chronos.Agent/Extraction/OllamaLlmAdapter.cs
+++ b/src/Chronos.Agent/Extraction/OllamaLlmAdapter.cs
@@ -7,7 +7,7 @@ using Chronos.Agent.Configuration;
 namespace Chronos.Agent.Extraction;
 
 /// <summary>
-/// LLM adapter for the university Ollama API (https://132.73.84.84/api/chat).
+/// LLM adapter for the university Ollama API.
 /// Supports the Ollama chat endpoint with optional JSON mode.
 /// </summary>
 public class OllamaLlmAdapter : ILlmAdapter

--- a/src/Chronos.Agent/README.md
+++ b/src/Chronos.Agent/README.md
@@ -23,7 +23,7 @@ User sends message
 └──────┬───────────────┘
        │
        ├──► ILlmAdapter (polymorphic)
-       │     ├── OllamaLlmAdapter   → University API (132.73.84.84)
+       │     ├── OllamaLlmAdapter   → University Ollama API
        │     └── PuterLlmAdapter    → Puter free AI API
        │
        ├──► ConstraintExtractor
@@ -124,7 +124,7 @@ Returns `AgentResponse` with current state, assistant message, draft, and allowe
 
 #### `LlmProviderOptions.cs`
 Configuration classes for the two LLM providers:
-- **`OllamaOptions`** — `BaseUrl`, `Model` (defaults: `https://132.73.84.84`, `llama4`)
+- **`OllamaOptions`** — `BaseUrl`, `Model` (defaults: empty, `phi3`)
 - **`PuterOptions`** — `BaseUrl`, `ApiToken`, `Model` (defaults: `https://api.puter.com`, `gpt-4o-mini`)
 
 Both bind from `appsettings.json` under `Agent:Ollama` and `Agent:Puter` sections.
@@ -186,7 +186,7 @@ Task<LlmResponse> ChatAsync(
 - `LlmOptions { Model?, JsonMode }` — optional overrides per request
 
 #### `OllamaLlmAdapter.cs`
-Adapter for the **university Ollama API** (`https://132.73.84.84/api/chat`):
+Adapter for the **university Ollama API**:
 - Sends `POST /api/chat` with `{ model, messages, stream: false }`
 - Supports `JsonMode` via Ollama's `format: "json"` parameter
 - Model can be overridden per-request via `LlmOptions.Model`
@@ -327,7 +327,7 @@ Configuration in `appsettings.json`:
 {
   "Agent": {
     "Ollama": {
-      "BaseUrl": "https://132.73.84.84",
+      "BaseUrl": "",
       "Model": "llama4"
     },
     "Puter": {

--- a/src/Chronos.MainApi/Agent/AgentController.cs
+++ b/src/Chronos.MainApi/Agent/AgentController.cs
@@ -1,0 +1,140 @@
+using Chronos.Agent;
+using Chronos.Agent.Conversation;
+using Chronos.Agent.Extraction;
+using Chronos.MainApi.Agent.Contracts;
+using Chronos.MainApi.Shared.Controllers.Utils;
+using Chronos.MainApi.Shared.Extensions;
+using Chronos.MainApi.Shared.Middleware;
+using Chronos.Shared.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Chronos.MainApi.Agent;
+
+[ApiController]
+[Route("api/agent")]
+[RequireOrganization]
+[Authorize]
+public class AgentController(
+    ILogger<AgentController> logger,
+    AgentOrchestrator orchestrator,
+    IConversationStore conversationStore)
+    : ControllerBase
+{
+    [HttpPost("sessions")]
+    public async Task<IActionResult> StartSession([FromBody] StartSessionRequest request)
+    {
+        var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
+        var userId = User.GetUserId();
+
+        logger.LogInformation("Agent: starting session for user {UserId}", userId);
+
+        var sessionId = await orchestrator.StartSessionAsync(userId, organizationId, request.SchedulingPeriodId);
+
+        return CreatedAtAction(nameof(SendMessage), new { sessionId }, new { sessionId });
+    }
+
+    [HttpPost("sessions/{sessionId}/messages")]
+    public async Task<IActionResult> SendMessage(Guid sessionId, [FromBody] SendMessageRequest request)
+    {
+        var userId = User.GetUserId();
+        var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
+
+        await VerifySessionOwnershipAsync(sessionId, userId, organizationId);
+
+        logger.LogInformation("Agent: message in session {SessionId}", sessionId);
+
+        var result = await ExecuteAgentActionAsync(() => orchestrator.SendMessageAsync(sessionId, request.Message));
+        return Ok(ToResponse(sessionId, result));
+    }
+
+    [HttpPost("sessions/{sessionId}/submit")]
+    public async Task<IActionResult> RequestSubmit(Guid sessionId)
+    {
+        var userId = User.GetUserId();
+        var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
+
+        await VerifySessionOwnershipAsync(sessionId, userId, organizationId);
+
+        logger.LogInformation("Agent: submit requested for session {SessionId}", sessionId);
+
+        var result = await ExecuteAgentActionAsync(() => orchestrator.RequestSubmitAsync(sessionId));
+        return Ok(ToResponse(sessionId, result));
+    }
+
+    [HttpPost("sessions/{sessionId}/approve")]
+    public async Task<IActionResult> Approve(Guid sessionId)
+    {
+        var userId = User.GetUserId();
+        var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
+
+        await VerifySessionOwnershipAsync(sessionId, userId, organizationId);
+
+        logger.LogInformation("Agent: approval for session {SessionId}", sessionId);
+
+        var result = await ExecuteAgentActionAsync(() => orchestrator.ApproveAsync(sessionId));
+        return Ok(ToResponse(sessionId, result));
+    }
+
+    [HttpPost("sessions/{sessionId}/revise")]
+    public async Task<IActionResult> Revise(Guid sessionId)
+    {
+        var userId = User.GetUserId();
+        var organizationId = ControllerUtils.GetOrganizationIdAndFailIfMissing(HttpContext, logger);
+
+        await VerifySessionOwnershipAsync(sessionId, userId, organizationId);
+
+        logger.LogInformation("Agent: revision requested for session {SessionId}", sessionId);
+
+        var result = await ExecuteAgentActionAsync(() => orchestrator.ReviseAsync(sessionId));
+        return Ok(ToResponse(sessionId, result));
+    }
+
+    private async Task VerifySessionOwnershipAsync(Guid sessionId, Guid userId, Guid organizationId)
+    {
+        var session = await conversationStore.GetAsync(sessionId);
+        if (session is null)
+            throw new NotFoundException($"Session {sessionId} not found.");
+
+        if (session.UserId != userId || session.OrganizationId != organizationId)
+            throw new UnauthorizedException("You do not own this session.");
+    }
+
+    private static async Task<AgentResponse> ExecuteAgentActionAsync(Func<Task<AgentResponse>> action)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            throw new NotFoundException(ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new BadRequestException(ex.Message);
+        }
+        catch (ExtractionException ex)
+        {
+            throw new BadRequestException($"Constraint extraction failed: {ex.Message}");
+        }
+    }
+
+    private static AgentSessionResponse ToResponse(Guid sessionId, AgentResponse result)
+    {
+        DraftResponse? draftResponse = null;
+        if (result.Draft is not null)
+        {
+            draftResponse = new DraftResponse(
+                result.Draft.HardConstraints.Select(c => new DraftItemResponse(c.Key, c.Value)).ToList(),
+                result.Draft.SoftPreferences.Select(p => new DraftItemResponse(p.Key, p.Value)).ToList());
+        }
+
+        return new AgentSessionResponse(
+            sessionId,
+            result.State,
+            result.AssistantMessage,
+            draftResponse,
+            result.AllowedActions);
+    }
+}

--- a/src/Chronos.MainApi/Agent/AgentModuleDiExtension.cs
+++ b/src/Chronos.MainApi/Agent/AgentModuleDiExtension.cs
@@ -1,0 +1,70 @@
+using Chronos.Agent;
+using Chronos.Agent.Configuration;
+using Chronos.Agent.Conversation;
+using Chronos.Agent.Extraction;
+using Chronos.Agent.Submission;
+using Chronos.MainApi.Schedule.Services;
+
+namespace Chronos.MainApi.Agent;
+
+public static class AgentModuleDiExtension
+{
+    public static void AddAgentModule(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Configuration
+        services.Configure<OllamaOptions>(configuration.GetSection(OllamaOptions.SectionName));
+        services.Configure<PuterOptions>(configuration.GetSection(PuterOptions.SectionName));
+
+        // Conversation store (in-memory, thread-safe — POC only)
+        services.AddSingleton<IConversationStore, InMemoryConversationStore>();
+
+        // LLM adapter — selected by config
+        var provider = configuration.GetValue<string>("Agent:LlmProvider") ?? "ollama";
+
+        if (provider.Equals("puter", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddHttpClient<ILlmAdapter, PuterLlmAdapter>((sp, client) => { })
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler());
+
+            services.AddScoped<ILlmAdapter>(sp =>
+            {
+                var options = configuration.GetSection(PuterOptions.SectionName).Get<PuterOptions>() ?? new PuterOptions();
+                var factory = sp.GetRequiredService<IHttpClientFactory>();
+                var client = factory.CreateClient(nameof(PuterLlmAdapter));
+                return new PuterLlmAdapter(client, options);
+            });
+        }
+        else
+        {
+            // Ollama with self-signed cert bypass (university server)
+            services.AddHttpClient("OllamaClient")
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+                });
+
+            services.AddScoped<ILlmAdapter>(sp =>
+            {
+                var options = configuration.GetSection(OllamaOptions.SectionName).Get<OllamaOptions>() ?? new OllamaOptions();
+                var factory = sp.GetRequiredService<IHttpClientFactory>();
+                var client = factory.CreateClient("OllamaClient");
+                return new OllamaLlmAdapter(client, options);
+            });
+        }
+
+        // Extraction
+        services.AddScoped<ConstraintExtractor>();
+
+        // Service adapters (bridge existing Chronos services → agent interfaces)
+        services.AddScoped<IAgentConstraintService>(sp =>
+            new UserConstraintServiceAdapter(sp.GetRequiredService<IUserConstraintService>()));
+        services.AddScoped<IAgentPreferenceService>(sp =>
+            new UserPreferenceServiceAdapter(sp.GetRequiredService<IUserPreferenceService>()));
+
+        // Submission
+        services.AddScoped<IAgentSubmitter, ServiceBackedSubmitter>();
+
+        // Orchestrator
+        services.AddScoped<AgentOrchestrator>();
+    }
+}

--- a/src/Chronos.MainApi/Agent/Contracts/AgentRequests.cs
+++ b/src/Chronos.MainApi/Agent/Contracts/AgentRequests.cs
@@ -1,0 +1,5 @@
+namespace Chronos.MainApi.Agent.Contracts;
+
+public record StartSessionRequest(Guid SchedulingPeriodId);
+
+public record SendMessageRequest(string Message);

--- a/src/Chronos.MainApi/Agent/Contracts/AgentResponses.cs
+++ b/src/Chronos.MainApi/Agent/Contracts/AgentResponses.cs
@@ -1,0 +1,17 @@
+using Chronos.Agent.Conversation;
+using Chronos.Agent.Domain;
+
+namespace Chronos.MainApi.Agent.Contracts;
+
+public record AgentSessionResponse(
+    Guid SessionId,
+    AgentState State,
+    string? AssistantMessage,
+    DraftResponse? Draft,
+    IReadOnlySet<AgentAction> AllowedActions);
+
+public record DraftResponse(
+    IReadOnlyList<DraftItemResponse> HardConstraints,
+    IReadOnlyList<DraftItemResponse> SoftPreferences);
+
+public record DraftItemResponse(string Key, string Value);

--- a/src/Chronos.MainApi/Agent/UserConstraintServiceAdapter.cs
+++ b/src/Chronos.MainApi/Agent/UserConstraintServiceAdapter.cs
@@ -1,0 +1,24 @@
+using Chronos.Agent.Submission;
+using Chronos.MainApi.Schedule.Services;
+
+namespace Chronos.MainApi.Agent;
+
+/// <summary>
+/// Adapts the existing IUserConstraintService to the agent's IAgentConstraintService interface.
+/// </summary>
+public class UserConstraintServiceAdapter : IAgentConstraintService
+{
+    private readonly IUserConstraintService _inner;
+
+    public UserConstraintServiceAdapter(IUserConstraintService inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public Task<Guid> CreateUserConstraintAsync(
+        Guid organizationId, Guid userId, Guid schedulingPeriodId,
+        string key, string value, int? weekNum = null)
+    {
+        return _inner.CreateUserConstraintAsync(organizationId, userId, schedulingPeriodId, key, value, weekNum);
+    }
+}

--- a/src/Chronos.MainApi/Agent/UserPreferenceServiceAdapter.cs
+++ b/src/Chronos.MainApi/Agent/UserPreferenceServiceAdapter.cs
@@ -1,0 +1,24 @@
+using Chronos.Agent.Submission;
+using Chronos.MainApi.Schedule.Services;
+
+namespace Chronos.MainApi.Agent;
+
+/// <summary>
+/// Adapts the existing IUserPreferenceService to the agent's IAgentPreferenceService interface.
+/// </summary>
+public class UserPreferenceServiceAdapter : IAgentPreferenceService
+{
+    private readonly IUserPreferenceService _inner;
+
+    public UserPreferenceServiceAdapter(IUserPreferenceService inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public Task<Guid> CreateUserPreferenceAsync(
+        Guid organizationId, Guid userId, Guid schedulingPeriodId,
+        string key, string value)
+    {
+        return _inner.CreateUserPreferenceAsync(organizationId, userId, schedulingPeriodId, key, value);
+    }
+}

--- a/src/Chronos.MainApi/AppSettings/appsettings.json
+++ b/src/Chronos.MainApi/AppSettings/appsettings.json
@@ -16,5 +16,17 @@
         "DiscordWebhookUrl": "",
         "MinimumLogLevel": "Information",
         "FlushIntervalSeconds": 30
+    },
+    "Agent": {
+        "LlmProvider": "ollama",
+        "Ollama": {
+            "BaseUrl": "",
+            "Model": "phi3"
+        },
+        "Puter": {
+            "BaseUrl": "https://api.puter.com",
+            "ApiToken": "",
+            "Model": "gpt-4o-mini"
+        }
     }
 }

--- a/src/Chronos.MainApi/Chronos.MainApi.csproj
+++ b/src/Chronos.MainApi/Chronos.MainApi.csproj
@@ -25,6 +25,7 @@
 
 
     <ItemGroup>
+      <ProjectReference Include="..\Chronos.Agent\Chronos.Agent.csproj" />
       <ProjectReference Include="..\Chronos.Data\Chronos.Data.csproj" />
       <ProjectReference Include="..\Chronos.Domain\Chronos.Domain.csproj" />
       <ProjectReference Include="..\Chronos.Shared\Chronos.Shared.csproj" />

--- a/src/Chronos.MainApi/Dockerfile
+++ b/src/Chronos.MainApi/Dockerfile
@@ -8,6 +8,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/Chronos.MainApi/Chronos.MainApi.csproj", "src/Chronos.MainApi/"]
+COPY ["src/Chronos.Agent/Chronos.Agent.csproj", "src/Chronos.Agent/"]
 COPY ["src/Chronos.Data/Chronos.Data.csproj", "src/Chronos.Data/"]
 COPY ["src/Chronos.Domain/Chronos.Domain.csproj", "src/Chronos.Domain/"]
 COPY ["src/Chronos.Shared/Chronos.Shared.csproj", "src/Chronos.Shared/"]

--- a/src/Chronos.MainApi/Program.cs
+++ b/src/Chronos.MainApi/Program.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Chronos.Data;
 using Chronos.Data.Context;
+using Chronos.MainApi.Agent;
 using Chronos.MainApi.Auth;
 using Chronos.MainApi.Auth.Configuration;
 using Chronos.MainApi.Management;
@@ -53,6 +54,7 @@ builder.Services.AddManagementModule(builder.Configuration);
 builder.Services.AddResourcesModule(builder.Configuration);
 builder.Services.AddScheduleModule(builder.Configuration);
 builder.Services.AddSharedModule(builder.Configuration);
+builder.Services.AddAgentModule(builder.Configuration);
 
 
 // Configure JWT Authentication

--- a/tests/Chronos.Tests.Agent/AgentControllerTests.cs
+++ b/tests/Chronos.Tests.Agent/AgentControllerTests.cs
@@ -1,0 +1,195 @@
+using Chronos.Agent;
+using Chronos.Agent.Conversation;
+using Chronos.Agent.Domain;
+using Chronos.Agent.Extraction;
+using Chronos.Agent.Submission;
+using Chronos.MainApi.Agent;
+using Chronos.MainApi.Agent.Contracts;
+using Chronos.Shared.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Security.Claims;
+
+namespace Chronos.Tests.Agent;
+
+public class AgentControllerTests
+{
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _orgId = Guid.NewGuid();
+    private readonly Guid _periodId = Guid.NewGuid();
+
+    private readonly Mock<ILlmAdapter> _llmAdapter = new();
+    private readonly Mock<IAgentSubmitter> _submitter = new();
+    private readonly InMemoryConversationStore _store = new();
+    private readonly Mock<ILogger<AgentController>> _logger = new();
+
+    private AgentController CreateController()
+    {
+        var extractor = new ConstraintExtractor(_llmAdapter.Object);
+        var orchestrator = new AgentOrchestrator(_llmAdapter.Object, extractor, _submitter.Object, _store);
+
+        var controller = new AgentController(_logger.Object, orchestrator, _store);
+
+        // Setup HttpContext with auth claims
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, _userId.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var httpContext = new DefaultHttpContext { User = principal };
+        httpContext.Items["organizationId"] = _orgId.ToString();
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        return controller;
+    }
+
+    private void SetupLlm(string conversationReply = "Got it!")
+    {
+        _llmAdapter
+            .Setup(a => a.ChatAsync(
+                It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.Is<LlmOptions?>(o => o == null || !o.JsonMode),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlmResponse(conversationReply));
+
+        var json = """{"hardConstraints":[{"key":"avoid_weekday","value":"Friday"}],"softPreferences":[{"key":"preferred_weekday","value":"Monday"}]}""";
+        _llmAdapter
+            .Setup(a => a.ChatAsync(
+                It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.Is<LlmOptions?>(o => o != null && o.JsonMode),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlmResponse(json));
+
+        _submitter
+            .Setup(s => s.SubmitAsync(It.IsAny<ConstraintProposal>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task StartSession_ReturnsCreated_WithSessionId()
+    {
+        SetupLlm();
+        var controller = CreateController();
+
+        var result = await controller.StartSession(new StartSessionRequest(_periodId));
+
+        var created = Assert.IsType<CreatedAtActionResult>(result);
+        Assert.NotNull(created.Value);
+    }
+
+    [Fact]
+    public async Task SendMessage_ReturnsOk_WithAgentResponse()
+    {
+        SetupLlm("I understand you want to avoid Fridays.");
+        var controller = CreateController();
+
+        // Start session first
+        var startResult = await controller.StartSession(new StartSessionRequest(_periodId)) as CreatedAtActionResult;
+        var sessionId = (Guid)startResult!.RouteValues!["sessionId"]!;
+
+        var result = await controller.SendMessage(sessionId, new SendMessageRequest("I can't work Fridays"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<AgentSessionResponse>(ok.Value);
+        Assert.Equal(AgentState.Discovery, response.State);
+        Assert.Equal("I understand you want to avoid Fridays.", response.AssistantMessage);
+    }
+
+    [Fact]
+    public async Task FullFlow_StartThroughApprove_Works()
+    {
+        SetupLlm();
+        var controller = CreateController();
+
+        // Start
+        var startResult = await controller.StartSession(new StartSessionRequest(_periodId)) as CreatedAtActionResult;
+        var sessionId = (Guid)startResult!.RouteValues!["sessionId"]!;
+
+        // Message
+        await controller.SendMessage(sessionId, new SendMessageRequest("I can't work Fridays and prefer Mondays"));
+
+        // Submit
+        var submitResult = await controller.RequestSubmit(sessionId) as OkObjectResult;
+        var submitResponse = Assert.IsType<AgentSessionResponse>(submitResult!.Value);
+        Assert.Equal(AgentState.Submit, submitResponse.State);
+        Assert.NotNull(submitResponse.Draft);
+        Assert.Single(submitResponse.Draft!.HardConstraints);
+
+        // Approve
+        var approveResult = await controller.Approve(sessionId) as OkObjectResult;
+        var approveResponse = Assert.IsType<AgentSessionResponse>(approveResult!.Value);
+        Assert.Equal(AgentState.Approved, approveResponse.State);
+
+        _submitter.Verify(
+            s => s.SubmitAsync(It.IsAny<ConstraintProposal>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendMessage_UnknownSession_ThrowsNotFoundException()
+    {
+        SetupLlm();
+        var controller = CreateController();
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => controller.SendMessage(Guid.NewGuid(), new SendMessageRequest("test")));
+    }
+
+    [Fact]
+    public async Task Approve_NotInSubmitState_ThrowsBadRequest()
+    {
+        SetupLlm();
+        var controller = CreateController();
+
+        var startResult = await controller.StartSession(new StartSessionRequest(_periodId)) as CreatedAtActionResult;
+        var sessionId = (Guid)startResult!.RouteValues!["sessionId"]!;
+
+        await Assert.ThrowsAsync<BadRequestException>(
+            () => controller.Approve(sessionId));
+    }
+
+    [Fact]
+    public async Task SendMessage_WrongUser_ThrowsUnauthorized()
+    {
+        SetupLlm();
+        var controller = CreateController();
+
+        // Start session with this user
+        var startResult = await controller.StartSession(new StartSessionRequest(_periodId)) as CreatedAtActionResult;
+        var sessionId = (Guid)startResult!.RouteValues!["sessionId"]!;
+
+        // Switch to a different user
+        var otherUserId = Guid.NewGuid();
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, otherUserId.ToString()) };
+        var identity = new ClaimsIdentity(claims, "Test");
+        controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(identity);
+
+        await Assert.ThrowsAsync<UnauthorizedException>(
+            () => controller.SendMessage(sessionId, new SendMessageRequest("test")));
+    }
+
+    [Fact]
+    public async Task Revise_AfterSubmit_TransitionsToRevision()
+    {
+        SetupLlm();
+        var controller = CreateController();
+
+        var startResult = await controller.StartSession(new StartSessionRequest(_periodId)) as CreatedAtActionResult;
+        var sessionId = (Guid)startResult!.RouteValues!["sessionId"]!;
+
+        await controller.SendMessage(sessionId, new SendMessageRequest("I can't work Fridays"));
+        await controller.RequestSubmit(sessionId);
+
+        var result = await controller.Revise(sessionId) as OkObjectResult;
+        var response = Assert.IsType<AgentSessionResponse>(result!.Value);
+        Assert.Equal(AgentState.Revision, response.State);
+    }
+}

--- a/tests/Chronos.Tests.Agent/Chronos.Tests.Agent.csproj
+++ b/tests/Chronos.Tests.Agent/Chronos.Tests.Agent.csproj
@@ -23,6 +23,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Chronos.Agent\Chronos.Agent.csproj" />
+    <!-- TODO: Move it out of here, I don't like the fact this project knows this: -->
+    <ProjectReference Include="..\..\src\Chronos.MainApi\Chronos.MainApi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Chronos.Tests.Agent/ServiceAdapterTests.cs
+++ b/tests/Chronos.Tests.Agent/ServiceAdapterTests.cs
@@ -1,0 +1,58 @@
+using Chronos.MainApi.Agent;
+using Chronos.MainApi.Schedule.Services;
+using Moq;
+
+namespace Chronos.Tests.Agent;
+
+public class ServiceAdapterTests
+{
+    private readonly Guid _orgId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _periodId = Guid.NewGuid();
+
+    [Fact]
+    public async Task UserConstraintServiceAdapter_DelegatesToInner()
+    {
+        var inner = new Mock<IUserConstraintService>();
+        var expectedId = Guid.NewGuid();
+        inner.Setup(s => s.CreateUserConstraintAsync(_orgId, _userId, _periodId, "avoid_weekday", "Friday", null))
+            .ReturnsAsync(expectedId);
+
+        var adapter = new UserConstraintServiceAdapter(inner.Object);
+
+        var result = await adapter.CreateUserConstraintAsync(_orgId, _userId, _periodId, "avoid_weekday", "Friday");
+
+        Assert.Equal(expectedId, result);
+        inner.Verify(s => s.CreateUserConstraintAsync(_orgId, _userId, _periodId, "avoid_weekday", "Friday", null), Times.Once);
+    }
+
+    [Fact]
+    public async Task UserConstraintServiceAdapter_PassesWeekNum()
+    {
+        var inner = new Mock<IUserConstraintService>();
+        inner.Setup(s => s.CreateUserConstraintAsync(_orgId, _userId, _periodId, "unavailable_day", "Monday", 3))
+            .ReturnsAsync(Guid.NewGuid());
+
+        var adapter = new UserConstraintServiceAdapter(inner.Object);
+
+        await adapter.CreateUserConstraintAsync(_orgId, _userId, _periodId, "unavailable_day", "Monday", 3);
+
+        inner.Verify(s => s.CreateUserConstraintAsync(_orgId, _userId, _periodId, "unavailable_day", "Monday", 3), Times.Once);
+    }
+
+    [Fact]
+    public async Task UserPreferenceServiceAdapter_DelegatesToInner()
+    {
+        var inner = new Mock<IUserPreferenceService>();
+        var expectedId = Guid.NewGuid();
+        inner.Setup(s => s.CreateUserPreferenceAsync(_orgId, _userId, _periodId, "preferred_weekday", "Monday"))
+            .ReturnsAsync(expectedId);
+
+        var adapter = new UserPreferenceServiceAdapter(inner.Object);
+
+        var result = await adapter.CreateUserPreferenceAsync(_orgId, _userId, _periodId, "preferred_weekday", "Monday");
+
+        Assert.Equal(expectedId, result);
+        inner.Verify(s => s.CreateUserPreferenceAsync(_orgId, _userId, _periodId, "preferred_weekday", "Monday"), Times.Once);
+    }
+}


### PR DESCRIPTION
# Bootstrap Agent Service into MainApi

## Summary

Integrates the `Chronos.Agent` class library (conversational scheduling AI) into the MainApi as a fully operational module — DI registration, REST endpoints, service adapters, Docker support, configuration, tests, and documentation.

## What's Included

### Core Integration (`src/Chronos.MainApi/Agent/`)
- **AgentController** — 5 REST endpoints: start session, send message, submit constraints, approve draft, revise draft
- **AgentModuleDiExtension** — DI wiring for all agent services, LLM provider selection (Ollama/Puter), scoped cert bypass for university server
- **UserConstraintServiceAdapter** / **UserPreferenceServiceAdapter** — bridge existing MainApi services to agent interfaces
- **Contracts** — request/response DTOs following existing API conventions

### Bug Fix (`src/Chronos.Agent/Extraction/`)
- **ConstraintExtractor** — fixed to handle non-string JSON values (boolean/number) returned by smaller LLM models (e.g., phi3 outputs `true` as JSON boolean, not `"true"`)

### Infrastructure
- **Dockerfile** — added `Chronos.Agent.csproj` to the restore stage
- **Program.cs** — registered `AddAgentModule`
- **appsettings.json** / `.env.example` — agent configuration section
- **ServiceProxy env-template** — added agent vars to `.api.example.env.example`

### Tests
- 7 controller tests (session creation, message flow, full flow, error mapping, auth)
- 3 service adapter delegation tests
- All 92 tests pass (82 existing + 10 new)

### Documentation
- **`doc/agent-api.md`** — full API reference with endpoints, request/response examples, error codes, configuration, and architecture overview

### Security
- Removed hardcoded Ollama server IP from all git-tracked files
- IP now lives exclusively in `.local.env` (gitignored)
- All public files use empty/placeholder values

## Endpoints Added

| Method | Route | Description |
|--------|-------|-------------|
| POST | `/api/agent/sessions` | Start a new agent conversation session |
| POST | `/api/agent/sessions/{id}/messages` | Send a message to the agent |
| POST | `/api/agent/sessions/{id}/submit` | Submit conversation for constraint extraction |
| POST | `/api/agent/sessions/{id}/approve` | Approve extracted draft → persist to DB |
| POST | `/api/agent/sessions/{id}/revise` | Revise draft with feedback |

## Auth & Security
- All endpoints require JWT authentication
- Session ownership enforced (users can only access their own sessions)
- `x-org-id` header required (existing org middleware)
- Errors mapped to existing exception types (404, 400, 401)

## Configuration

```env
Agent__LlmProvider=ollama          # or "puter"
Agent__Ollama__BaseUrl=            # university server URL (set in .local.env)
Agent__Ollama__Model=phi3
Agent__Puter__BaseUrl=https://api.puter.com
Agent__Puter__ApiToken=            # required if using puter
Agent__Puter__Model=gpt-4o-mini
```

## Verified
- ✅ Solution builds with 0 errors
- ✅ 92 tests pass
- ✅ Docker image builds successfully
- ✅ End-to-end flow verified with real LLM (phi3 via Ollama)
- ✅ Constraints & preferences written to PostgreSQL on approval
- ✅ No secrets in git-tracked files
