### PR TITLE
feat(schedule): add InitiatedByUserId to scheduling domain messages

### DIFF
--- a/src/Chronos.Domain/Schedule/Messages/HandleConstraintChangeRequest.cs
+++ b/src/Chronos.Domain/Schedule/Messages/HandleConstraintChangeRequest.cs
@@ -8,6 +8,7 @@ public record HandleConstraintChangeRequest(
     ConstraintChangeOperation Operation = ConstraintChangeOperation.Created,
     Guid? ActivityId = null,
     Guid? UserId = null,
-    SchedulingMode Mode = SchedulingMode.Online
+    SchedulingMode Mode = SchedulingMode.Online,
+    Guid? InitiatedByUserId = null
 );
 

--- a/src/Chronos.Domain/Schedule/Messages/SchedulePeriodRequest.cs
+++ b/src/Chronos.Domain/Schedule/Messages/SchedulePeriodRequest.cs
@@ -3,6 +3,7 @@ namespace Chronos.Domain.Schedule.Messages;
 public record SchedulePeriodRequest(
     Guid SchedulingPeriodId,
     Guid OrganizationId,
-    SchedulingMode Mode = SchedulingMode.Batch
+    SchedulingMode Mode = SchedulingMode.Batch,
+    Guid? InitiatedByUserId = null
 );
 

--- a/src/Chronos.Domain/Schedule/Messages/SchedulingResult.cs
+++ b/src/Chronos.Domain/Schedule/Messages/SchedulingResult.cs
@@ -6,6 +6,7 @@ public record SchedulingResult(
     int AssignmentsCreated,
     int AssignmentsModified,
     List<Guid> UnscheduledActivityIds,
-    string? FailureReason
+    string? FailureReason,
+    Guid? InitiatedByUserId = null
 );
 


### PR DESCRIPTION
### Summary
Introduces an optional initiator id on the three core scheduling messages so later PRs can thread the authenticated user from API → queue → engine → result → notifications without breaking existing serialization.

### Changes
| Area | Detail |
|------|--------|
| `SchedulePeriodRequest` | New optional `InitiatedByUserId` (default `null`). |
| `HandleConstraintChangeRequest` | Same. |
| `SchedulingResult` | Same; engine will copy from request when building results. |

### Technical notes
- Uses optional positional record parameters so existing `new SchedulingResult(..., failureReason)` call sites can omit the last argument where defaults apply.
- JSON from older producers omitting the field should bind with `null` when deserialized with System.Text.Json (verify in integration tests in consuming PRs if needed).

### How to test
- `dotnet build` on `Chronos.Domain` (or full solution).
- No new unit tests required for DTO-only change; compilation of dependents will be validated in follow-up PRs.

### Risk / rollout
**Low.** Additive contract only. Deploy order: merge and publish Domain package **before** Engine/MainApi PRs that reference the new member, or merge all in dependency order within the same release train.

### Related issues
- Links to: Engine propagation issue, MainApi initiator issue, SignalR consumer issue (when filed).

### Files in this PR (only)
- `Chronos.Service/src/Chronos.Domain/Schedule/Messages/SchedulePeriodRequest.cs`
- `Chronos.Service/src/Chronos.Domain/Schedule/Messages/HandleConstraintChangeRequest.cs`
- `Chronos.Service/src/Chronos.Domain/Schedule/Messages/SchedulingResult.cs`