### PR TITLE
feat(api): set scheduling InitiatedByUserId on batch and constraint publishes

### DIFF
--- a/src/Chronos.MainApi/Schedule/Controllers/ScheduleController.cs
+++ b/src/Chronos.MainApi/Schedule/Controllers/ScheduleController.cs
@@ -4,6 +4,7 @@ using Chronos.MainApi.Schedule.Extensions;
 using Chronos.MainApi.Schedule.Messaging;
 using Chronos.MainApi.Schedule.Services;
 using Chronos.MainApi.Shared.Controllers.Utils;
+using Chronos.MainApi.Shared.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -333,7 +334,8 @@ public class ScheduleController(
         var request = new SchedulePeriodRequest(
             SchedulingPeriodId: schedulingPeriodId,
             OrganizationId: organizationId,
-            Mode: SchedulingMode.Batch
+            Mode: SchedulingMode.Batch,
+            InitiatedByUserId: User.GetUserId()
         );
 
         // Publish to RabbitMQ

--- a/src/Chronos.MainApi/Schedule/Services/ActivityConstraintService.cs
+++ b/src/Chronos.MainApi/Schedule/Services/ActivityConstraintService.cs
@@ -5,6 +5,7 @@ using Chronos.Data.Repositories.Schedule;
 using Chronos.Domain.Schedule;
 using Chronos.Domain.Schedule.Messages;
 using Chronos.MainApi.Schedule.Messaging;
+using Chronos.MainApi.Shared.Extensions;
 using Chronos.MainApi.Shared.ExternalMangement;
 using Chronos.Shared.Exceptions;
 
@@ -16,9 +17,27 @@ public class ActivityConstraintService(
     IManagementExternalService validationService,
     IMessagePublisher messagePublisher,
     IActivityRepository activityRepository,
-    ISubjectRepository subjectRepository
+    ISubjectRepository subjectRepository,
+    IHttpContextAccessor httpContextAccessor
 ) : IActivityConstraintService
 {
+    private Guid? GetInitiatingUserId()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        try
+        {
+            return user.GetUserId();
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
 
     public async Task<Guid> CreateActivityConstraintAsync(Guid organizationId, Guid activityId, string key, string value, int? weekNum = null)
@@ -53,7 +72,8 @@ public class ActivityConstraintService(
                 Operation: ConstraintChangeOperation.Created,
                 ActivityId: constraint.ActivityId,
                 UserId: null,
-                Mode: SchedulingMode.Online
+                Mode: SchedulingMode.Online,
+                InitiatedByUserId: GetInitiatingUserId()
             ),
             "request.online"
         );
@@ -111,7 +131,8 @@ public class ActivityConstraintService(
                 Operation: ConstraintChangeOperation.Updated,
                 ActivityId: constraint.ActivityId,
                 UserId: null,
-                Mode: SchedulingMode.Online
+                Mode: SchedulingMode.Online,
+                InitiatedByUserId: GetInitiatingUserId()
             ),
             "request.online"
         );
@@ -137,7 +158,8 @@ public class ActivityConstraintService(
                 Operation: ConstraintChangeOperation.Deleted,
                 ActivityId: constraint.ActivityId,
                 UserId: null,
-                Mode: SchedulingMode.Online
+                Mode: SchedulingMode.Online,
+                InitiatedByUserId: GetInitiatingUserId()
             ),
             "request.online"
         );

--- a/src/Chronos.MainApi/Schedule/Services/UserConstraintService.cs
+++ b/src/Chronos.MainApi/Schedule/Services/UserConstraintService.cs
@@ -2,6 +2,7 @@ using Chronos.Data.Repositories.Schedule;
 using Chronos.Domain.Schedule;
 using Chronos.Domain.Schedule.Messages;
 using Chronos.MainApi.Schedule.Messaging;
+using Chronos.MainApi.Shared.Extensions;
 using Chronos.MainApi.Shared.ExternalMangement;
 using Chronos.Shared.Exceptions;
 
@@ -11,8 +12,26 @@ public class UserConstraintService(
     IManagementExternalService validationService,
     ISchedulingPeriodService schedulingPeriodService,
     ILogger<UserConstraintService> logger,
-    IMessagePublisher messagePublisher) : IUserConstraintService
+    IMessagePublisher messagePublisher,
+    IHttpContextAccessor httpContextAccessor) : IUserConstraintService
 {
+    private Guid? GetInitiatingUserId()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        try
+        {
+            return user.GetUserId();
+        }
+        catch
+        {
+            return null;
+        }
+    }
     public async Task<Guid> CreateUserConstraintAsync(Guid organizationId, Guid userId, Guid schedulingPeriodId, string key, string value, int? weekNum = null)
     {
         await validationService.ValidateOrganizationAsync(organizationId);
@@ -38,7 +57,8 @@ public class UserConstraintService(
                 Operation: ConstraintChangeOperation.Created,
                 ActivityId: null,
                 UserId: userId,
-                Mode: SchedulingMode.Online
+                Mode: SchedulingMode.Online,
+                InitiatedByUserId: GetInitiatingUserId()
             ),
             "request.online"
         );
@@ -113,7 +133,8 @@ public class UserConstraintService(
                 Operation: ConstraintChangeOperation.Updated,
                 ActivityId: null,
                 UserId: constraint.UserId,
-                Mode: SchedulingMode.Online
+                Mode: SchedulingMode.Online,
+                InitiatedByUserId: GetInitiatingUserId()
             ),
             "request.online"
         );
@@ -136,7 +157,8 @@ public class UserConstraintService(
                 Operation: ConstraintChangeOperation.Deleted,
                 ActivityId: null,
                 UserId: constraint.UserId,
-                Mode: SchedulingMode.Online
+                Mode: SchedulingMode.Online,
+                InitiatedByUserId: GetInitiatingUserId()
             ),
             "request.online"
         );

--- a/tests/Chronos.Tests.MainApi/Services/Schedule/ActivityConstraintServiceTests.cs
+++ b/tests/Chronos.Tests.MainApi/Services/Schedule/ActivityConstraintServiceTests.cs
@@ -6,6 +6,7 @@ using Chronos.MainApi.Schedule.Messaging;
 using Chronos.MainApi.Schedule.Services;
 using Chronos.MainApi.Shared.ExternalMangement;
 using Chronos.Shared.Exceptions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
@@ -34,13 +35,17 @@ public class ActivityConstraintServiceTests
         _messagePublisher = Substitute.For<IMessagePublisher>();
         _logger = Substitute.For<ILogger<ActivityConstraintService>>();
 
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns((HttpContext?)null);
+
         _service = new ActivityConstraintService(
             _activityConstraintRepository,
             _logger,
             _validationService,
             _messagePublisher,
             _activityRepository,
-            _subjectRepository);
+            _subjectRepository,
+            httpContextAccessor);
     }
 
     #region CreateActivityConstraintAsync Tests

--- a/tests/Chronos.Tests.MainApi/Services/Schedule/UserConstraintServiceTests.cs
+++ b/tests/Chronos.Tests.MainApi/Services/Schedule/UserConstraintServiceTests.cs
@@ -4,6 +4,7 @@ using Chronos.MainApi.Schedule.Messaging;
 using Chronos.MainApi.Schedule.Services;
 using Chronos.MainApi.Shared.ExternalMangement;
 using Chronos.Shared.Exceptions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
@@ -30,12 +31,16 @@ public class UserConstraintServiceTests
         _messagePublisher = Substitute.For<IMessagePublisher>();
         _logger = Substitute.For<ILogger<UserConstraintService>>();
 
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns((HttpContext?)null);
+
         _service = new UserConstraintService(
             _userConstraintRepository,
             _validationService,
             _schedulingPeriodService,
             _logger,
-            _messagePublisher);
+            _messagePublisher,
+            httpContextAccessor);
     }
 
     #region CreateUserConstraintAsync Tests


### PR DESCRIPTION
### Summary
Populates **`InitiatedByUserId`** on **`SchedulePeriodRequest`** and **`HandleConstraintChangeRequest`** using the current JWT user, so asynchronous engine results can be correlated with the triggering operator.

### Implementation details
- **`ScheduleController`:** `User.GetUserId()` on batch enqueue.
- **`UserConstraintService` / `ActivityConstraintService`:** `IHttpContextAccessor` + safe resolver for initiator guid.
- **Tests:** `IHttpContextAccessor` mock with null **`HttpContext`** where existing tests do not model a request.

### Testing
```bash
dotnet test tests/Chronos.Tests.MainApi/Chronos.Tests.MainApi.csproj
```
- Manually: trigger batch or constraint change; inspect published JSON (optional) for **`initiatedByUserId`** in dev.

### Risk / rollout
**Low.** Additive fields on messages; null initiator if unauthenticated or no HTTP context (should not occur for these authorized controller/service entry points in normal operation).

### Rollback
Revert PR; messages revert to **`initiatedByUserId: null`**; notifications won’t target users until re-deployed.

### Files in this PR (only)
- `Chronos.Service/src/Chronos.MainApi/Schedule/Controllers/ScheduleController.cs`
- `Chronos.Service/src/Chronos.MainApi/Schedule/Services/UserConstraintService.cs`
- `Chronos.Service/src/Chronos.MainApi/Schedule/Services/ActivityConstraintService.cs`
- `Chronos.Service/tests/Chronos.Tests.MainApi/Services/Schedule/ActivityConstraintServiceTests.cs`
- `Chronos.Service/tests/Chronos.Tests.MainApi/Services/Schedule/UserConstraintServiceTests.cs`
