### PR TITLE
feat(api): scheduling result consumer, SignalR hub, JWT negotiate hook, CORS for SignalR

### DIFF
--- a/src/Chronos.MainApi/Program.cs
+++ b/src/Chronos.MainApi/Program.cs
@@ -7,6 +7,7 @@ using Chronos.MainApi.Auth.Configuration;
 using Chronos.MainApi.Management;
 using Chronos.MainApi.Resources;
 using Chronos.MainApi.Schedule;
+using Chronos.MainApi.Schedule.Messaging;
 using Chronos.MainApi.Shared;
 using Chronos.MainApi.Shared.Extensions;
 using Chronos.MainApi.Shared.Middleware;
@@ -56,6 +57,7 @@ builder.Services.AddScheduleModule(builder.Configuration);
 builder.Services.AddSharedModule(builder.Configuration);
 builder.Services.AddAgentModule(builder.Configuration);
 
+builder.Services.AddSignalR();
 
 // Configure JWT Authentication
 var authConfig = builder.Configuration.GetSection(nameof(AuthConfiguration)).Get<AuthConfiguration>();
@@ -76,6 +78,19 @@ builder.Services.AddAuthentication(options =>
         ValidAudience = authConfig.Audience,
         ValidateLifetime = true,
         ClockSkew = TimeSpan.Zero
+    };
+    options.Events = new JwtBearerEvents
+    {
+        OnMessageReceived = context =>
+        {
+            var accessToken = context.Request.Query["access_token"];
+            if (!string.IsNullOrEmpty(accessToken) &&
+                context.HttpContext.Request.Path.StartsWithSegments("/hubs/scheduling"))
+            {
+                context.Token = accessToken;
+            }
+            return Task.CompletedTask;
+        }
     };
 });
 
@@ -127,9 +142,10 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
     {
-        policy.AllowAnyOrigin()
+        policy.WithOrigins("http://localhost:5173")
             .AllowAnyHeader()
-            .AllowAnyMethod();
+            .AllowAnyMethod()
+            .AllowCredentials();
     });
 });
 
@@ -152,6 +168,7 @@ app.UseAuthorization();
 // app.UseHttpsRedirection();
 app.UseHttpMetrics();   // tracks request duration, count, and status codes
 app.MapControllers();
+app.MapHub<SchedulingNotificationsHub>("/hubs/scheduling");
 app.MapMetrics();       // exposes /metrics endpoint for Prometheus to scrape
 
 app.Run();

--- a/src/Chronos.MainApi/Schedule/Messaging/RabbitMqOptions.cs
+++ b/src/Chronos.MainApi/Schedule/Messaging/RabbitMqOptions.cs
@@ -11,5 +11,6 @@ public class RabbitMqOptions
     public string VirtualHost { get; set; } = "/";
     public string BatchQueueName { get; set; } = "chronos.scheduling.batch";
     public string OnlineQueueName { get; set; } = "chronos.scheduling.online";
+    public string ResultsQueueName { get; set; } = "chronos.scheduling.results";
     public string ExchangeName { get; set; } = "chronos.scheduling";
 }

--- a/src/Chronos.MainApi/Schedule/Messaging/SchedulingNotificationsHub.cs
+++ b/src/Chronos.MainApi/Schedule/Messaging/SchedulingNotificationsHub.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Chronos.MainApi.Schedule.Messaging;
+
+[Authorize]
+public class SchedulingNotificationsHub : Hub
+{
+}

--- a/src/Chronos.MainApi/Schedule/Messaging/SchedulingResultNotificationConsumer.cs
+++ b/src/Chronos.MainApi/Schedule/Messaging/SchedulingResultNotificationConsumer.cs
@@ -1,0 +1,87 @@
+using System.Text;
+using System.Text.Json;
+using Chronos.Domain.Schedule.Messages;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Chronos.MainApi.Schedule.Messaging;
+
+public class SchedulingResultNotificationConsumer(
+    IRabbitMqConnectionFactory connectionFactory,
+    IHubContext<SchedulingNotificationsHub> hubContext,
+    IOptions<RabbitMqOptions> options,
+    ILogger<SchedulingResultNotificationConsumer> logger
+) : BackgroundService
+{
+    private readonly IRabbitMqConnectionFactory _connectionFactory = connectionFactory;
+    private readonly IHubContext<SchedulingNotificationsHub> _hubContext = hubContext;
+    private readonly RabbitMqOptions _options = options.Value;
+    private readonly ILogger<SchedulingResultNotificationConsumer> _logger = logger;
+    private IModel? _channel;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _channel = _connectionFactory.CreateChannel();
+        _channel.ExchangeDeclare(_options.ExchangeName, "topic", durable: true, autoDelete: false);
+        _channel.QueueDeclare(_options.ResultsQueueName, durable: true, exclusive: false, autoDelete: false);
+        _channel.QueueBind(_options.ResultsQueueName, _options.ExchangeName, routingKey: "result.#");
+        _channel.BasicQos(0, 1, false);
+
+        var consumer = new EventingBasicConsumer(_channel);
+        consumer.Received += async (_, ea) =>
+        {
+            try
+            {
+                var json = Encoding.UTF8.GetString(ea.Body.ToArray());
+                var result = JsonSerializer.Deserialize<SchedulingResult>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                });
+
+                if (result?.InitiatedByUserId is { } userId)
+                {
+                    await _hubContext.Clients.User(userId.ToString()).SendAsync(
+                        "SchedulingCompleted",
+                        new
+                        {
+                            requestId = result.RequestId,
+                            success = result.Success,
+                            assignmentsCreated = result.AssignmentsCreated,
+                            assignmentsModified = result.AssignmentsModified,
+                            unscheduledActivityIds = result.UnscheduledActivityIds.Select(id => id.ToString()).ToArray(),
+                            failureReason = result.FailureReason,
+                        },
+                        stoppingToken);
+                }
+
+                _channel!.BasicAck(ea.DeliveryTag, false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to process scheduling result notification");
+                _channel!.BasicNack(ea.DeliveryTag, false, true);
+            }
+        };
+
+        _channel.BasicConsume(_options.ResultsQueueName, autoAck: false, consumer);
+        _logger.LogInformation("Scheduling result consumer listening on {Queue}", _options.ResultsQueueName);
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+    }
+
+    public override void Dispose()
+    {
+        _channel?.Close();
+        _channel?.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Chronos.MainApi/Schedule/ModuleDiExtension.cs
+++ b/src/Chronos.MainApi/Schedule/ModuleDiExtension.cs
@@ -32,5 +32,7 @@ public static class ModuleDiExtension
         services.AddScoped<IExternalActivityService, ExternalActivityService>();
         services.AddScoped<IExternalResourceService, ExternalResourceService>();
         services.AddScoped<IExternalSubjectService, ExternalSubjectService>();
+
+        services.AddHostedService<SchedulingResultNotificationConsumer>();
     }
 }


### PR DESCRIPTION
### Summary
Adds a hosted RabbitMQ consumer for scheduling **results**, forwards them to the initiating user over **SignalR**, wires **JWT** for hub negotiate via **`access_token`**, and tightens **CORS** so browser negotiate works with credentials.

### What changed
| Component | Purpose |
|-----------|---------|
| **`RabbitMqOptions.ResultsQueueName`** | Dedicated queue for API to consume engine results. |
| **`SchedulingResultNotificationConsumer`** | Binds **`result.#`**, deserializes **`SchedulingResult`**, pushes hub event. |
| **`SchedulingNotificationsHub`** | Authorized endpoint for browser connections. |
| **`ModuleDiExtension`** | Registers **`AddHostedService`** for consumer. |
| **`Program.cs`** | **`AddSignalR`**, **`MapHub`**, **`JwtBearerEvents.OnMessageReceived`**, CORS **`WithOrigins` + `AllowCredentials`**. |

### Contract (client)
- Hub method/event name: **`SchedulingCompleted`** (client listens).
- Payload: includes **`requestId`**, **`success`**, **`assignmentsCreated`**, **`assignmentsModified`**, **`unscheduledActivityIds`**, **`failureReason`** (shape should match whatever the consumer sends; camelCase JSON typical for SignalR serialization).

### Testing
- `dotnet build` MainApi.
- **Integration (manual):** Run RabbitMQ, Engine, MainApi; trigger batch from UI or API; confirm hub receives event when JWT user matches initiator.
- **CORS:** Open portal on **`http://localhost:5173`**; confirm negotiate no longer fails with wildcard error.

### Risk / rollout
**Medium.** New long-running consumer + public hub surface + CORS behavior change for all API CORS responses using this policy (now explicit origin + credentials). Verify other dev origins (e.g. **`127.0.0.1`**, alternate ports) if teams use them.

### Rollback
Disable hosted service registration or revert PR; remove **`MapHub`** if reverting fully. CORS may need revert to previous policy if non-SignalR clients depended on `*` (unlikely for credentialed flows).

### Files in this PR (only)
- `Chronos.Service/src/Chronos.MainApi/Schedule/Messaging/RabbitMqOptions.cs`
- `Chronos.Service/src/Chronos.MainApi/Schedule/Messaging/SchedulingNotificationsHub.cs`
- `Chronos.Service/src/Chronos.MainApi/Schedule/Messaging/SchedulingResultNotificationConsumer.cs`
- `Chronos.Service/src/Chronos.MainApi/Schedule/ModuleDiExtension.cs`
- `Chronos.Service/src/Chronos.MainApi/Program.cs`
