### PR TITLE
chronos-admin: platform auth services

### DIFF
--- a/src/Chronos.Admin/AppSettings/appsettings.json
+++ b/src/Chronos.Admin/AppSettings/appsettings.json
@@ -12,7 +12,11 @@
     "CredStorePath": "./data/admin-creds.db",
     "DefaultEmail": "",
     "DefaultPassword": "",
+    "DefaultFirstName": "Platform",
+    "DefaultLastName": "Administrator",
     "SecretKey": "",
+    "Issuer": "ChronosAdmin",
+    "Audience": "ChronosAdminCli",
     "TokenExpiryMinutes": 480
   }
 }

--- a/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs
+++ b/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs
@@ -1,0 +1,24 @@
+using Chronos.Admin.Auth.Services;
+using Chronos.Admin.CredStore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Chronos.Admin.Auth;
+
+public static class AdminAuthModuleExtensions
+{
+    public static IServiceCollection AddAdminAuthModule(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddAdminCredStore(configuration);
+
+        services.AddScoped<IAdminAuthService, AdminAuthService>();
+        services.AddScoped<IAdminTokenGenerator, AdminTokenGenerator>();
+        services.AddScoped<IAdminBootstrapService, AdminBootstrapService>();
+
+        // Session: services.AddAdminSession(); — added in PR 3 (Auth/Session/AdminSessionModuleExtensions.cs)
+
+        return services;
+    }
+}

--- a/src/Chronos.Admin/Auth/Contracts/AuthResponse.cs
+++ b/src/Chronos.Admin/Auth/Contracts/AuthResponse.cs
@@ -1,0 +1,3 @@
+namespace Chronos.Admin.Auth.Contracts;
+
+public record AuthResponse(string Token);

--- a/src/Chronos.Admin/Auth/Contracts/CreateUserRequest.cs
+++ b/src/Chronos.Admin/Auth/Contracts/CreateUserRequest.cs
@@ -1,0 +1,3 @@
+namespace Chronos.Admin.Auth.Contracts;
+
+public record CreateUserRequest(string Email, string FirstName, string LastName, string Password);

--- a/src/Chronos.Admin/Auth/Contracts/LoginRequest.cs
+++ b/src/Chronos.Admin/Auth/Contracts/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace Chronos.Admin.Auth.Contracts;
+
+public record LoginRequest(string Email, string Password);

--- a/src/Chronos.Admin/Auth/Contracts/UserResponse.cs
+++ b/src/Chronos.Admin/Auth/Contracts/UserResponse.cs
@@ -1,0 +1,11 @@
+namespace Chronos.Admin.Auth.Contracts;
+
+public record UserResponse(
+    string Id,
+    string Email,
+    string FirstName,
+    string LastName,
+    string? AvatarUrl,
+    bool Verified,
+    bool IsBootstrap,
+    DateTime CreatedAt);

--- a/src/Chronos.Admin/Auth/Extensions/AdminUserMapper.cs
+++ b/src/Chronos.Admin/Auth/Extensions/AdminUserMapper.cs
@@ -1,0 +1,18 @@
+using Chronos.Admin.Auth.Contracts;
+using Chronos.Admin.CredStore.Entities;
+
+namespace Chronos.Admin.Auth.Extensions;
+
+public static class AdminUserMapper
+{
+    public static UserResponse ToUserResponse(this AdminUser user) =>
+        new(
+            user.Id.ToString(),
+            user.Email,
+            user.FirstName,
+            user.LastName,
+            user.AvatarUrl,
+            user.Verified,
+            user.IsBootstrap,
+            user.CreatedAt);
+}

--- a/src/Chronos.Admin/Auth/Services/AdminAuthService.cs
+++ b/src/Chronos.Admin/Auth/Services/AdminAuthService.cs
@@ -1,0 +1,67 @@
+using Chronos.Admin.Auth.Contracts;
+using Chronos.Admin.Auth.Extensions;
+using Chronos.Admin.Auth.Validation;
+using Chronos.Admin.CredStore.Entities;
+using Chronos.Admin.CredStore.Repositories;
+using Chronos.Shared.Exceptions;
+using BCryptNet = BCrypt.Net.BCrypt;
+
+namespace Chronos.Admin.Auth.Services;
+
+public class AdminAuthService(
+    IAdminUserRepository userRepository,
+    IAdminTokenGenerator tokenGenerator) : IAdminAuthService
+{
+    public async Task<AuthResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
+    {
+        EmailValidator.ValidateEmail(request.Email);
+
+        var user = await userRepository.GetByEmailAsync(request.Email, cancellationToken);
+
+        if (user is null || !BCryptNet.Verify(request.Password, user.PasswordHash))
+        {
+            throw new UnauthorizedException("Invalid credentials");
+        }
+
+        var token = await tokenGenerator.GenerateTokenAsync(user);
+        return new AuthResponse(token);
+    }
+
+    public async Task<UserResponse> AddAccountAsync(
+        CreateUserRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        EmailValidator.ValidateEmail(request.Email);
+
+        if (await userRepository.EmailExistsAsync(request.Email, cancellationToken))
+        {
+            throw new BadRequestException("User with this email already exists");
+        }
+
+        PasswordValidator.ValidatePassword(request.Password);
+
+        var now = DateTime.UtcNow;
+        var user = new AdminUser
+        {
+            Id = Guid.NewGuid(),
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Email = request.Email,
+            PasswordHash = BCryptNet.HashPassword(request.Password),
+            Verified = false,
+            IsBootstrap = false,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await userRepository.AddAsync(user, cancellationToken);
+        return user.ToUserResponse();
+    }
+
+    public async Task<IReadOnlyList<UserResponse>> ListAccountsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var users = await userRepository.GetAllAsync(cancellationToken);
+        return users.Select(u => u.ToUserResponse()).ToList();
+    }
+}

--- a/src/Chronos.Admin/Auth/Services/AdminBootstrapService.cs
+++ b/src/Chronos.Admin/Auth/Services/AdminBootstrapService.cs
@@ -1,0 +1,63 @@
+using Chronos.Admin.Auth.Validation;
+using Chronos.Admin.Configuration;
+using Chronos.Admin.CredStore.Entities;
+using Chronos.Admin.CredStore.Repositories;
+using Microsoft.Extensions.Options;
+using BCryptNet = BCrypt.Net.BCrypt;
+
+namespace Chronos.Admin.Auth.Services;
+
+public class AdminBootstrapService(
+    IAdminUserRepository userRepository,
+    IOptions<AdminConfiguration> config) : IAdminBootstrapService
+{
+    public async Task EnsureBootstrapAsync(CancellationToken cancellationToken = default)
+    {
+        if (await userRepository.CountAsync(cancellationToken) > 0)
+        {
+            return;
+        }
+
+        var settings = config.Value;
+
+        if (string.IsNullOrWhiteSpace(settings.DefaultEmail)
+            || string.IsNullOrWhiteSpace(settings.DefaultPassword))
+        {
+            throw new InvalidOperationException(
+                "No platform admin accounts exist. Set AdminConfiguration__DefaultEmail and "
+                + "AdminConfiguration__DefaultPassword (and AdminConfiguration__SecretKey) then run login.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.SecretKey) || settings.SecretKey.Length < 32)
+        {
+            throw new InvalidOperationException(
+                "AdminConfiguration__SecretKey must be set (minimum 32 characters) before bootstrap.");
+        }
+
+        EmailValidator.ValidateEmail(settings.DefaultEmail);
+        PasswordValidator.ValidatePassword(settings.DefaultPassword);
+
+        var firstName = string.IsNullOrWhiteSpace(settings.DefaultFirstName)
+            ? "Platform"
+            : settings.DefaultFirstName;
+        var lastName = string.IsNullOrWhiteSpace(settings.DefaultLastName)
+            ? "Administrator"
+            : settings.DefaultLastName;
+
+        var now = DateTime.UtcNow;
+        var user = new AdminUser
+        {
+            Id = Guid.NewGuid(),
+            Email = settings.DefaultEmail.Trim(),
+            FirstName = firstName,
+            LastName = lastName,
+            PasswordHash = BCryptNet.HashPassword(settings.DefaultPassword),
+            Verified = true,
+            IsBootstrap = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await userRepository.AddAsync(user, cancellationToken);
+    }
+}

--- a/src/Chronos.Admin/Auth/Services/AdminTokenGenerator.cs
+++ b/src/Chronos.Admin/Auth/Services/AdminTokenGenerator.cs
@@ -1,0 +1,39 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Chronos.Admin.Configuration;
+using Chronos.Admin.CredStore.Entities;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Chronos.Admin.Auth.Services;
+
+public class AdminTokenGenerator(IOptions<AdminConfiguration> config) : IAdminTokenGenerator
+{
+    private readonly JwtSecurityTokenHandler _tokenHandler = new();
+    private readonly AdminConfiguration _config = config.Value;
+
+    public Task<string> GenerateTokenAsync(AdminUser user)
+    {
+        var key = Encoding.UTF8.GetBytes(_config.SecretKey);
+        var cred = new SigningCredentials(
+            new SymmetricSecurityKey(key),
+            SecurityAlgorithms.HmacSha256Signature);
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config.Issuer,
+            Audience = _config.Audience,
+            Subject = new ClaimsIdentity([
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Email, user.Email),
+                new Claim(ClaimTypes.Name, $"{user.FirstName} {user.LastName}")
+            ]),
+            SigningCredentials = cred,
+            Expires = DateTime.UtcNow.AddMinutes(_config.TokenExpiryMinutes)
+        };
+
+        var token = _tokenHandler.CreateToken(tokenDescriptor);
+        return Task.FromResult(_tokenHandler.WriteToken(token));
+    }
+}

--- a/src/Chronos.Admin/Auth/Services/IAdminAuthService.cs
+++ b/src/Chronos.Admin/Auth/Services/IAdminAuthService.cs
@@ -1,0 +1,10 @@
+using Chronos.Admin.Auth.Contracts;
+
+namespace Chronos.Admin.Auth.Services;
+
+public interface IAdminAuthService
+{
+    Task<AuthResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default);
+    Task<UserResponse> AddAccountAsync(CreateUserRequest request, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<UserResponse>> ListAccountsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Chronos.Admin/Auth/Services/IAdminBootstrapService.cs
+++ b/src/Chronos.Admin/Auth/Services/IAdminBootstrapService.cs
@@ -1,0 +1,6 @@
+namespace Chronos.Admin.Auth.Services;
+
+public interface IAdminBootstrapService
+{
+    Task EnsureBootstrapAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Chronos.Admin/Auth/Services/IAdminTokenGenerator.cs
+++ b/src/Chronos.Admin/Auth/Services/IAdminTokenGenerator.cs
@@ -1,0 +1,8 @@
+using Chronos.Admin.CredStore.Entities;
+
+namespace Chronos.Admin.Auth.Services;
+
+public interface IAdminTokenGenerator
+{
+    Task<string> GenerateTokenAsync(AdminUser user);
+}

--- a/src/Chronos.Admin/Auth/Validation/EmailValidator.cs
+++ b/src/Chronos.Admin/Auth/Validation/EmailValidator.cs
@@ -1,0 +1,30 @@
+using System.Text.RegularExpressions;
+using Chronos.Shared.Exceptions;
+
+namespace Chronos.Admin.Auth.Validation;
+
+public static class EmailValidator
+{
+    private const int MaxLength = 254;
+    private static readonly Regex EmailRegex = new(
+        @"^[^@\s]+@[^@\s]+\.[^@\s]+$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static void ValidateEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new BadRequestException("Email cannot be empty");
+        }
+
+        if (email.Length > MaxLength)
+        {
+            throw new BadRequestException($"Email must not exceed {MaxLength} characters");
+        }
+
+        if (!EmailRegex.IsMatch(email))
+        {
+            throw new BadRequestException("Email format is invalid");
+        }
+    }
+}

--- a/src/Chronos.Admin/Auth/Validation/PasswordValidator.cs
+++ b/src/Chronos.Admin/Auth/Validation/PasswordValidator.cs
@@ -1,0 +1,47 @@
+using Chronos.Shared.Exceptions;
+
+namespace Chronos.Admin.Auth.Validation;
+
+public static class PasswordValidator
+{
+    private const int MinLength = 8;
+    private const int MaxLength = 128;
+
+    public static void ValidatePassword(string password)
+    {
+        if (string.IsNullOrEmpty(password))
+        {
+            throw new BadRequestException("Password cannot be empty");
+        }
+
+        if (password.Length < MinLength)
+        {
+            throw new BadRequestException($"Password must be at least {MinLength} characters long");
+        }
+
+        if (password.Length > MaxLength)
+        {
+            throw new BadRequestException($"Password must not exceed {MaxLength} characters");
+        }
+
+        if (password.Any(char.IsWhiteSpace))
+        {
+            throw new BadRequestException("Password cannot contain whitespace characters");
+        }
+
+        if (!password.Any(char.IsUpper))
+        {
+            throw new BadRequestException("Password must contain at least one uppercase letter (A-Z)");
+        }
+
+        if (!password.Any(char.IsLower))
+        {
+            throw new BadRequestException("Password must contain at least one lowercase letter (a-z)");
+        }
+
+        if (!password.Any(char.IsDigit))
+        {
+            throw new BadRequestException("Password must contain at least one digit (0-9)");
+        }
+    }
+}

--- a/src/Chronos.Admin/Program.cs
+++ b/src/Chronos.Admin/Program.cs
@@ -1,3 +1,4 @@
+using Chronos.Admin.Auth;
 using Chronos.Admin.CredStore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,7 @@ builder.Configuration
     .AddEnvironmentVariables();
 
 builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-builder.Services.AddAdminCredStore(builder.Configuration);
+builder.Services.AddAdminAuthModule(builder.Configuration);
 
 using var host = builder.Build();
 


### PR DESCRIPTION
## Summary

- Implements platform admin authentication services aligned with `Chronos.MainApi/Auth/` (validators, BCrypt, JWT issuance) without referencing `Chronos.MainApi`.
- Adds login, account creation, and account listing logic against `IAdminUserRepository`.
- Adds bootstrap seeding: when the cred store is empty, creates the first `IsBootstrap` admin from `AdminConfiguration` environment variables.
- Issues admin JWTs with distinct issuer/audience (`ChronosAdmin` / `ChronosAdminCli`) and identity claims only (no organization or roles claims).

Session file persistence and CLI commands are deferred to PRs 3 and 4.

## Changes (expected files)

- `Chronos.Service/src/Chronos.Admin/Auth/Validation/**` (`EmailValidator`, `PasswordValidator`)
- `Chronos.Service/src/Chronos.Admin/Auth/Contracts/**`
- `Chronos.Service/src/Chronos.Admin/Auth/Services/**` (`AdminAuthService`, `AdminTokenGenerator`, `AdminBootstrapService`, interfaces)
- `Chronos.Service/src/Chronos.Admin/Auth/Extensions/AdminUserMapper.cs`
- `Chronos.Service/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs` (calls `AddAdminCredStore`, registers auth services; no session)
- `Chronos.Service/src/Chronos.Admin/Program.cs` (`AddAdminAuthModule` instead of `AddAdminCredStore`)
- `Chronos.Service/src/Chronos.Admin/Configuration/AdminConfiguration.cs` (`SecretKey`, `Issuer`, `Audience`, `TokenExpiryMinutes`, bootstrap email/password/names)
- `Chronos.Service/src/Chronos.Admin/AppSettings/appsettings.json`
- `Chronos.Service/src/Chronos.Admin/Chronos.Admin.csproj` (`BCrypt.Net-Next`, `System.IdentityModel.Tokens.Jwt`)

## Test plan

- [ ] `dotnet build src/Chronos.Admin/Chronos.Admin.csproj`
- [ ] With empty DB and env vars set (`DefaultEmail`, `DefaultPassword`, `SecretKey` ≥ 32 chars), bootstrap creates one `IsBootstrap` user
- [ ] `AdminAuthService.LoginAsync` succeeds for bootstrap user with correct password; fails with `UnauthorizedException` for wrong password
- [ ] `AddAccountAsync` enforces `PasswordValidator` and duplicate-email check
- [ ] Generated JWT validates with admin issuer/audience/secret and does **not** validate against MainApi `AuthConfiguration`

## Notes for reviewers

- Validators are duplicated from MainApi for Phase 2; consolidating into `Chronos.Shared` is a possible follow-up.
- Bootstrap requires `SecretKey` length ≥ 32 characters before seeding.
