### PR TITLE
chronos-admin: CLI session handling

### DIFF
--- a/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs
+++ b/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs
@@ -1,4 +1,5 @@
 using Chronos.Admin.Auth.Services;
+using Chronos.Admin.Auth.Session;
 using Chronos.Admin.CredStore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,7 +18,7 @@ public static class AdminAuthModuleExtensions
         services.AddScoped<IAdminTokenGenerator, AdminTokenGenerator>();
         services.AddScoped<IAdminBootstrapService, AdminBootstrapService>();
 
-        // Session: services.AddAdminSession(); — added in PR 3 (Auth/Session/AdminSessionModuleExtensions.cs)
+        services.AddAdminSession();
 
         return services;
     }

--- a/src/Chronos.Admin/Auth/Session/AdminSessionGuard.cs
+++ b/src/Chronos.Admin/Auth/Session/AdminSessionGuard.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using Chronos.Shared.Exceptions;
+
+namespace Chronos.Admin.Auth.Session;
+
+public class AdminSessionGuard(
+    IAdminSessionStore sessionStore,
+    IAdminTokenValidator tokenValidator) : IAdminSessionGuard
+{
+    public async Task<ClaimsPrincipal> RequireValidSessionAsync(CancellationToken cancellationToken = default)
+    {
+        var token = await sessionStore.ReadTokenAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new AdminSessionRequiredException("Authentication required. Run login first.");
+        }
+
+        if (tokenValidator.IsExpired(token))
+        {
+            throw new AdminSessionRequiredException("Session expired. Run login again.");
+        }
+
+        var principal = tokenValidator.ValidateToken(token);
+        if (principal is null)
+        {
+            throw new AdminSessionRequiredException("Invalid session. Run login again.");
+        }
+
+        return principal;
+    }
+}

--- a/src/Chronos.Admin/Auth/Session/AdminSessionModuleExtensions.cs
+++ b/src/Chronos.Admin/Auth/Session/AdminSessionModuleExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Chronos.Admin.Auth.Session;
+
+/// <summary>
+/// CLI session file persistence and JWT validation for platform admin commands.
+/// </summary>
+public static class AdminSessionModuleExtensions
+{
+    public static IServiceCollection AddAdminSession(this IServiceCollection services)
+    {
+        services.AddSingleton<IAdminSessionStore, AdminSessionStore>();
+        services.AddSingleton<IAdminTokenValidator, AdminTokenValidator>();
+        services.AddSingleton<IAdminSessionGuard, AdminSessionGuard>();
+
+        return services;
+    }
+}

--- a/src/Chronos.Admin/Auth/Session/AdminSessionRequiredException.cs
+++ b/src/Chronos.Admin/Auth/Session/AdminSessionRequiredException.cs
@@ -1,0 +1,3 @@
+namespace Chronos.Admin.Auth.Session;
+
+public sealed class AdminSessionRequiredException(string message) : Exception(message);

--- a/src/Chronos.Admin/Auth/Session/AdminSessionStore.cs
+++ b/src/Chronos.Admin/Auth/Session/AdminSessionStore.cs
@@ -1,0 +1,58 @@
+using System.Runtime.InteropServices;
+
+namespace Chronos.Admin.Auth.Session;
+
+public class AdminSessionStore : IAdminSessionStore
+{
+    public string SessionFilePath { get; } = ResolveSessionPath();
+
+    public async Task SaveTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(SessionFilePath)!;
+        Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(SessionFilePath, token.Trim(), cancellationToken);
+        TryRestrictPermissions(SessionFilePath);
+    }
+
+    public async Task<string?> ReadTokenAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(SessionFilePath))
+        {
+            return null;
+        }
+
+        var token = await File.ReadAllTextAsync(SessionFilePath, cancellationToken);
+        return string.IsNullOrWhiteSpace(token) ? null : token.Trim();
+    }
+
+    public Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        if (File.Exists(SessionFilePath))
+        {
+            File.Delete(SessionFilePath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static string ResolveSessionPath()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".chronos-admin", "session");
+    }
+
+    private static void TryRestrictPermissions(string filePath)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            try
+            {
+                File.SetUnixFileMode(filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            catch
+            {
+                // Best effort only.
+            }
+        }
+    }
+}

--- a/src/Chronos.Admin/Auth/Session/AdminTokenValidator.cs
+++ b/src/Chronos.Admin/Auth/Session/AdminTokenValidator.cs
@@ -1,0 +1,58 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Chronos.Admin.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Chronos.Admin.Auth.Session;
+
+public class AdminTokenValidator(IOptions<AdminConfiguration> config) : IAdminTokenValidator
+{
+    private readonly AdminConfiguration _config = config.Value;
+    private readonly JwtSecurityTokenHandler _handler = new();
+
+    public ClaimsPrincipal? ValidateToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(_config.SecretKey))
+        {
+            return null;
+        }
+
+        try
+        {
+            var parameters = BuildValidationParameters();
+            return _handler.ValidateToken(token, parameters, out _);
+        }
+        catch (SecurityTokenException)
+        {
+            return null;
+        }
+    }
+
+    public bool IsExpired(string token)
+    {
+        try
+        {
+            var jwt = _handler.ReadJwtToken(token);
+            return jwt.ValidTo < DateTime.UtcNow;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private TokenValidationParameters BuildValidationParameters() =>
+        new()
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config.SecretKey)),
+            ValidateIssuer = true,
+            ValidIssuer = _config.Issuer,
+            ValidateAudience = true,
+            ValidAudience = _config.Audience,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        };
+}

--- a/src/Chronos.Admin/Auth/Session/IAdminSessionGuard.cs
+++ b/src/Chronos.Admin/Auth/Session/IAdminSessionGuard.cs
@@ -1,0 +1,8 @@
+using System.Security.Claims;
+
+namespace Chronos.Admin.Auth.Session;
+
+public interface IAdminSessionGuard
+{
+    Task<ClaimsPrincipal> RequireValidSessionAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Chronos.Admin/Auth/Session/IAdminSessionStore.cs
+++ b/src/Chronos.Admin/Auth/Session/IAdminSessionStore.cs
@@ -1,0 +1,9 @@
+namespace Chronos.Admin.Auth.Session;
+
+public interface IAdminSessionStore
+{
+    string SessionFilePath { get; }
+    Task SaveTokenAsync(string token, CancellationToken cancellationToken = default);
+    Task<string?> ReadTokenAsync(CancellationToken cancellationToken = default);
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Chronos.Admin/Auth/Session/IAdminTokenValidator.cs
+++ b/src/Chronos.Admin/Auth/Session/IAdminTokenValidator.cs
@@ -1,0 +1,9 @@
+using System.Security.Claims;
+
+namespace Chronos.Admin.Auth.Session;
+
+public interface IAdminTokenValidator
+{
+    ClaimsPrincipal? ValidateToken(string token);
+    bool IsExpired(string token);
+}


### PR DESCRIPTION
## Summary

- Adds local session persistence for the admin CLI: JWT written to `~/.chronos-admin/session` (Windows: `%USERPROFILE%\.chronos-admin\session`).
- Validates stored tokens with the same rules as MainApi JWT middleware (issuer, audience, signing key, lifetime, zero clock skew), without hosting Kestrel or `AddJwtBearer`.
- Introduces `AdminSessionGuard` so protected operations can require a valid session and return exit code **2** when missing or expired.

CLI command wiring remains in PR 4; this PR is the session layer only.

## Changes (expected files)

- `Chronos.Service/src/Chronos.Admin/Auth/Session/**` (`AdminSessionStore`, `AdminTokenValidator`, `AdminSessionGuard`, `AdminSessionRequiredException`, interfaces)
- `Chronos.Service/src/Chronos.Admin/Auth/Session/AdminSessionModuleExtensions.cs` (`AddAdminSession`)
- `Chronos.Service/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs` (uncomment/add `services.AddAdminSession();`)

## Test plan

- [ ] `dotnet build src/Chronos.Admin/Chronos.Admin.csproj`
- [ ] After saving a token via `AdminSessionStore`, `AdminTokenValidator` accepts it with configured issuer/audience
- [ ] Expired or tampered token is rejected; `AdminSessionGuard` throws `AdminSessionRequiredException`
- [ ] Session file directory is created on first save; permissions are restricted on Unix where supported
- [ ] Admin JWT does not validate when checked with MainApi `AuthConfiguration` (different issuer/audience/secret)

## Notes for reviewers

- `AdminSessionRequiredException` maps to CLI exit code 2 in PR 4 (`AdminExitCodes`).
- Session path is per OS user, not per cred-store path.
