### PR TITLE
chronos-admin: login and accounts CLI

### DIFF
--- a/src/Chronos.Admin/Cli/AdminCommandRoot.cs
+++ b/src/Chronos.Admin/Cli/AdminCommandRoot.cs
@@ -1,0 +1,212 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Chronos.Admin.Auth.Contracts;
+using Chronos.Admin.Auth.Services;
+using Chronos.Admin.Auth.Session;
+using Chronos.Admin.Cli.Output;
+using Chronos.Shared.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Chronos.Admin.Cli;
+
+public static class AdminCommandRoot
+{
+    public static RootCommand Build(IHost host)
+    {
+        var root = new RootCommand("Chronos platform administration CLI.");
+
+        var emailOption = new Option<string?>("--email", "Platform admin email address.");
+        var passwordOption = new Option<string?>("--password", "Password (prompted if omitted).");
+        var firstNameOption = new Option<string>("--first-name", "Account first name.") { IsRequired = true };
+        var lastNameOption = new Option<string>("--last-name", "Account last name.") { IsRequired = true };
+
+        var loginCommand = new Command("login", "Sign in and save a session for later commands.");
+        loginCommand.AddOption(emailOption);
+        loginCommand.AddOption(passwordOption);
+        loginCommand.SetHandler(async (InvocationContext context) =>
+        {
+            var email = context.ParseResult.GetValueForOption(emailOption);
+            var password = context.ParseResult.GetValueForOption(passwordOption);
+            context.ExitCode = await RunLoginAsync(host, email, password);
+        });
+
+        var accountsCommand = new Command("accounts", "Manage platform admin accounts.");
+
+        var accountsListCommand = new Command("list", "List platform admin accounts.");
+        accountsListCommand.SetHandler(async (InvocationContext context) =>
+        {
+            context.ExitCode = await RunAccountsListAsync(host);
+        });
+
+        var accountsAddCommand = new Command("add", "Add a platform admin account.");
+        var addEmailArgument = new Argument<string>("email", "Email address for the new account.");
+        accountsAddCommand.AddArgument(addEmailArgument);
+        accountsAddCommand.AddOption(firstNameOption);
+        accountsAddCommand.AddOption(lastNameOption);
+        accountsAddCommand.AddOption(passwordOption);
+        accountsAddCommand.SetHandler(async (InvocationContext context) =>
+        {
+            var email = context.ParseResult.GetValueForArgument(addEmailArgument);
+            var firstName = context.ParseResult.GetValueForOption(firstNameOption)!;
+            var lastName = context.ParseResult.GetValueForOption(lastNameOption)!;
+            var password = context.ParseResult.GetValueForOption(passwordOption);
+            context.ExitCode = await RunAccountsAddAsync(host, email, firstName, lastName, password);
+        });
+
+        accountsCommand.AddCommand(accountsListCommand);
+        accountsCommand.AddCommand(accountsAddCommand);
+
+        root.AddCommand(loginCommand);
+        root.AddCommand(accountsCommand);
+
+        return root;
+    }
+
+    private static async Task<int> RunLoginAsync(IHost host, string? email, string? password)
+    {
+        try
+        {
+            email = RequireValue(email, "Email");
+            password = RequireValue(password, "Password", secret: true);
+
+            using var scope = host.Services.CreateScope();
+            var bootstrap = scope.ServiceProvider.GetRequiredService<IAdminBootstrapService>();
+            var auth = scope.ServiceProvider.GetRequiredService<IAdminAuthService>();
+            var sessionStore = scope.ServiceProvider.GetRequiredService<IAdminSessionStore>();
+
+            await bootstrap.EnsureBootstrapAsync();
+            var response = await auth.LoginAsync(new LoginRequest(email, password));
+            await sessionStore.SaveTokenAsync(response.Token);
+
+            Console.WriteLine("Login successful.");
+            return AdminExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            return WriteError(ex);
+        }
+    }
+
+    private static async Task<int> RunAccountsListAsync(IHost host)
+    {
+        try
+        {
+            using var scope = host.Services.CreateScope();
+            var bootstrap = scope.ServiceProvider.GetRequiredService<IAdminBootstrapService>();
+            var sessionGuard = scope.ServiceProvider.GetRequiredService<IAdminSessionGuard>();
+            var auth = scope.ServiceProvider.GetRequiredService<IAdminAuthService>();
+
+            await bootstrap.EnsureBootstrapAsync();
+            await sessionGuard.RequireValidSessionAsync();
+
+            var accounts = await auth.ListAccountsAsync();
+            AdminAccountTableWriter.Write(accounts);
+            return AdminExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            return WriteError(ex);
+        }
+    }
+
+    private static async Task<int> RunAccountsAddAsync(
+        IHost host,
+        string email,
+        string firstName,
+        string lastName,
+        string? password)
+    {
+        try
+        {
+            password = RequireValue(password, "Password", secret: true);
+
+            using var scope = host.Services.CreateScope();
+            var bootstrap = scope.ServiceProvider.GetRequiredService<IAdminBootstrapService>();
+            var sessionGuard = scope.ServiceProvider.GetRequiredService<IAdminSessionGuard>();
+            var auth = scope.ServiceProvider.GetRequiredService<IAdminAuthService>();
+
+            await bootstrap.EnsureBootstrapAsync();
+            await sessionGuard.RequireValidSessionAsync();
+
+            var created = await auth.AddAccountAsync(
+                new CreateUserRequest(email, firstName, lastName, password));
+
+            Console.WriteLine($"Account created: {created.Email} ({created.Id})");
+            return AdminExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            return WriteError(ex);
+        }
+    }
+
+    private static string RequireValue(string? value, string prompt, bool secret = false)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        Console.Write($"{prompt}: ");
+        if (secret)
+        {
+            value = ReadSecret();
+        }
+        else
+        {
+            value = Console.ReadLine();
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{prompt} is required.");
+        }
+
+        return value;
+    }
+
+    private static string ReadSecret()
+    {
+        var buffer = new List<char>();
+        while (true)
+        {
+            var key = Console.ReadKey(intercept: true);
+            if (key.Key == ConsoleKey.Enter)
+            {
+                Console.WriteLine();
+                break;
+            }
+
+            if (key.Key == ConsoleKey.Backspace)
+            {
+                if (buffer.Count > 0)
+                {
+                    buffer.RemoveAt(buffer.Count - 1);
+                }
+
+                continue;
+            }
+
+            if (!char.IsControl(key.KeyChar))
+            {
+                buffer.Add(key.KeyChar);
+            }
+        }
+
+        return new string(buffer.ToArray());
+    }
+
+    private static int WriteError(Exception ex)
+    {
+        var message = ex switch
+        {
+            UnauthorizedException => "Invalid credentials.",
+            BadRequestException bad => bad.Message,
+            _ => ex.Message
+        };
+
+        Console.Error.WriteLine(message);
+        return AdminExitCodes.FromException(ex);
+    }
+}

--- a/src/Chronos.Admin/Cli/AdminExitCodes.cs
+++ b/src/Chronos.Admin/Cli/AdminExitCodes.cs
@@ -1,0 +1,22 @@
+using Chronos.Admin.Auth.Session;
+using Chronos.Shared.Exceptions;
+
+namespace Chronos.Admin.Cli;
+
+public static class AdminExitCodes
+{
+    public const int Success = 0;
+    public const int GeneralError = 1;
+    public const int AuthenticationRequired = 2;
+    public const int InvalidArguments = 3;
+
+    public static int FromException(Exception ex) =>
+        ex switch
+        {
+            AdminSessionRequiredException => AuthenticationRequired,
+            UnauthorizedException => GeneralError,
+            BadRequestException => InvalidArguments,
+            ArgumentException => InvalidArguments,
+            _ => GeneralError
+        };
+}

--- a/src/Chronos.Admin/Cli/Output/AdminAccountTableWriter.cs
+++ b/src/Chronos.Admin/Cli/Output/AdminAccountTableWriter.cs
@@ -1,0 +1,41 @@
+using Chronos.Admin.Auth.Contracts;
+
+namespace Chronos.Admin.Cli.Output;
+
+public static class AdminAccountTableWriter
+{
+    public static void Write(IReadOnlyList<UserResponse> accounts)
+    {
+        if (accounts.Count == 0)
+        {
+            Console.WriteLine("No platform admin accounts.");
+            return;
+        }
+
+        var rows = accounts.Select(a => new[]
+        {
+            a.Email,
+            $"{a.FirstName} {a.LastName}",
+            a.Verified ? "yes" : "no",
+            a.IsBootstrap ? "yes" : "no",
+            a.CreatedAt.ToString("u")
+        }).ToList();
+
+        var headers = new[] { "Email", "Name", "Verified", "Bootstrap", "Created (UTC)" };
+        var widths = headers.Select((h, i) =>
+            Math.Max(h.Length, rows.Max(r => r[i].Length))).ToArray();
+
+        Console.WriteLine(FormatRow(headers, widths));
+        Console.WriteLine(new string('-', widths.Sum() + (widths.Length - 1) * 2));
+
+        foreach (var row in rows)
+        {
+            Console.WriteLine(FormatRow(row, widths));
+        }
+    }
+
+    private static string FormatRow(string[] cells, int[] widths)
+    {
+        return string.Join("  ", cells.Select((cell, i) => cell.PadRight(widths[i])));
+    }
+}

--- a/src/Chronos.Admin/README.md
+++ b/src/Chronos.Admin/README.md
@@ -27,6 +27,12 @@ Table output is the default; `--json` is supported for scripting. See [docs/Chro
 
 ```bash
 # From the Chronos.Service repository root
+export AdminConfiguration__DefaultEmail=admin@internal.example
+export AdminConfiguration__DefaultPassword='<strong-password>'
+export AdminConfiguration__SecretKey='<signing-key-at-least-32-chars>'
+
+dotnet run --project src/Chronos.Admin -- login --email admin@internal.example
+dotnet run --project src/Chronos.Admin -- accounts list
 dotnet run --project src/Chronos.Admin -- --help
 ```
 
@@ -46,7 +52,9 @@ Settings live in `AppSettings/appsettings.json`. In deployment, prefer environme
 
 - `ConnectionStrings__DefaultConnection` — PostgreSQL (tenant data)
 - `AdminConfiguration__DefaultEmail` / `DefaultPassword` — first-run bootstrap admin
+- `AdminConfiguration__DefaultFirstName` / `DefaultLastName` — bootstrap profile names
 - `AdminConfiguration__CredStorePath` — SQLite file for admin accounts (default `./data/admin-creds.db`)
-- `AdminConfiguration__SecretKey` — signing key for admin sessions
+- `AdminConfiguration__SecretKey` — signing key for admin sessions (min 32 characters)
+- `AdminConfiguration__Issuer` / `Audience` — JWT issuer and audience (defaults `ChronosAdmin` / `ChronosAdminCli`)
 
 Full reference: [docs/Chronos.Admin.md](docs/Chronos.Admin.md#configuration-reference).

--- a/src/Chronos.Admin/docs/Chronos.Admin.md
+++ b/src/Chronos.Admin/docs/Chronos.Admin.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-**Phase 1 (current):** Project scaffold only. The CLI builds and prints a placeholder message. No authentication, SQLite, or tenant queries are implemented.
+**Phase 2 (current):** Platform admin authentication is implemented. SQLite stores `AdminUser` records (same profile/auth fields as MainApi `User`, without `OrganizationId`). Commands: `login`, `accounts add`, `accounts list`. Validators, BCrypt, and JWT issuance follow the same patterns as `Chronos.MainApi/Auth/`, adapted for the CLI session file.
+
+**Not yet implemented:** Cross-tenant `orgs` commands (Phase 3), Docker/CI/tests (Phase 4).
 
 See [Implementation phases](#implementation-phases) at the end of this document.
 
@@ -159,13 +161,15 @@ On first run, if the SQLite cred store has no accounts:
 
 1. Read `AdminConfiguration:DefaultEmail` and `AdminConfiguration:DefaultPassword` from configuration/environment.
 2. If either is missing, fail with a clear message directing the operator to set env vars.
-3. Create the first `AdminAccount` with `IsBootstrap = true` and a BCrypt password hash.
+3. Create the first `AdminUser` with `IsBootstrap = true` and a BCrypt password hash (profile fields match MainApi `User`; names from `DefaultFirstName` / `DefaultLastName`).
 
 Environment variable examples:
 
 ```text
 AdminConfiguration__DefaultEmail=admin@internal.example
 AdminConfiguration__DefaultPassword=<strong-secret>
+AdminConfiguration__DefaultFirstName=Platform
+AdminConfiguration__DefaultLastName=Administrator
 AdminConfiguration__SecretKey=<jwt-signing-key-min-32-chars>
 AdminConfiguration__CredStorePath=./data/admin-creds.db
 ```
@@ -196,19 +200,22 @@ Isolated from PostgreSQL migrations in `Chronos.Data`.
 
 ### DbContext
 
-`AdminCredDbContext` lives in `Chronos.Admin` only (planned folder: `CredStore/`).
+`AdminCredDbContext` lives in `Chronos.Admin/CredStore/`.
 
-### Schema sketch
+### Schema
 
-**Table: `AdminAccounts`**
+**Table: `AdminUsers`** (mirrors MainApi `User` minus `OrganizationId`)
 
 | Column | Type | Notes |
 |--------|------|-------|
 | `Id` | GUID | Primary key |
-| `Email` | string | Unique, normalized lowercase |
+| `Email` | string | Unique index |
 | `PasswordHash` | string | BCrypt |
+| `FirstName`, `LastName` | string | Profile (same as MainApi) |
+| `Verified` | bool | |
+| `AvatarUrl` | string? | Optional |
 | `IsBootstrap` | bool | First seeded account |
-| `CreatedAt` | DateTimeOffset | UTC |
+| `CreatedAt`, `UpdatedAt` | DateTime | UTC (`ObjectInformation`) |
 
 ### Connection
 
@@ -230,7 +237,7 @@ The admin CLI reads tenant data through existing `Chronos.Data` (`AppDbContext`)
 ConnectionStrings__DefaultConnection=Host=localhost;Database=chronos;...
 ```
 
-Registration (planned in `Program.cs`):
+Registration (planned in Phase 3):
 
 ```csharp
 services.AddDbContext<AppDbContext>(options =>
@@ -238,7 +245,7 @@ services.AddDbContext<AppDbContext>(options =>
 services.AddServiceRepositories(); // or targeted repository registration
 ```
 
-No `AppDbContext` registration exists in the scaffold to avoid requiring Postgres at startup.
+`AppDbContext` is not registered yet so the CLI does not require PostgreSQL at startup.
 
 ---
 
@@ -250,8 +257,13 @@ No `AppDbContext` registration exists in the scaffold to avoid requiring Postgre
 | `AdminConfiguration:CredStorePath` | `AdminConfiguration__CredStorePath` | SQLite file path |
 | `AdminConfiguration:DefaultEmail` | `AdminConfiguration__DefaultEmail` | Bootstrap admin email |
 | `AdminConfiguration:DefaultPassword` | `AdminConfiguration__DefaultPassword` | Bootstrap admin password |
-| `AdminConfiguration:SecretKey` | `AdminConfiguration__SecretKey` | Token signing key |
+| `AdminConfiguration:DefaultFirstName` | `AdminConfiguration__DefaultFirstName` | Bootstrap first name (default Platform) |
+| `AdminConfiguration:DefaultLastName` | `AdminConfiguration__DefaultLastName` | Bootstrap last name (default Administrator) |
+| `AdminConfiguration:SecretKey` | `AdminConfiguration__SecretKey` | Token signing key (min 32 chars for bootstrap) |
+| `AdminConfiguration:Issuer` | `AdminConfiguration__Issuer` | JWT issuer (default ChronosAdmin) |
+| `AdminConfiguration:Audience` | `AdminConfiguration__Audience` | JWT audience (default ChronosAdminCli) |
 | `AdminConfiguration:TokenExpiryMinutes` | `AdminConfiguration__TokenExpiryMinutes` | Session lifetime (default 480) |
+| `AdminConfiguration:CredStoreConnection` | `AdminConfiguration__CredStoreConnection` | Optional full SQLite connection string |
 
 Files:
 
@@ -300,8 +312,8 @@ Planned for Phase 4: Dockerfile, `docker-compose` service, publish workflow entr
 
 | Phase | Scope | Status |
 |-------|--------|--------|
-| **1** | Empty project, CLI stub, this design doc | **Done (scaffold)** |
-| **2** | SQLite `AdminCredDbContext`, bootstrap seed, `login`, `accounts add/list` | Planned |
+| **1** | Empty project, CLI stub, this design doc | **Done** |
+| **2** | SQLite `AdminCredDbContext`, bootstrap seed, `login`, `accounts add/list` | **Done** |
 | **3** | `orgs list` / `orgs show` via `Chronos.Data` cross-tenant reads | Planned |
 | **4** | Docker, CI publish, `.env.example`, tests (`Chronos.Tests.Admin`) | Planned |
 | **5** | Optional HTTP API | Future |


### PR DESCRIPTION
## Summary

- Wires the `Chronos.Admin` command-line interface for Phase 2: `login`, `accounts add`, and `accounts list`.
- Replaces the Phase 1 scaffold placeholder with a System.CommandLine tree and scoped DI handlers.
- Maps errors to documented exit codes (0 success, 1 general, 2 auth required/expired, 3 invalid arguments).
- Updates operator documentation (`README.md`, `docs/Chronos.Admin.md`) to mark Phase 2 complete.

## Commands

```bash
dotnet run --project src/Chronos.Admin -- login [--email] [--password]
dotnet run --project src/Chronos.Admin -- accounts list
dotnet run --project src/Chronos.Admin -- accounts add <email> --first-name <n> --last-name <n> [--password]
```

## Changes (expected files)

- `Chronos.Service/src/Chronos.Admin/Cli/**` (`AdminCommandRoot`, `AdminExitCodes`, `AdminAccountTableWriter`)
- `Chronos.Service/src/Chronos.Admin/Program.cs` (host bootstrap, migrations, invoke command root)
- `Chronos.Service/src/Chronos.Admin/README.md`
- `Chronos.Service/src/Chronos.Admin/docs/Chronos.Admin.md` (Phase 2 status, `AdminUsers` schema, configuration table)

## Test plan

- [ ] `dotnet build src/Chronos.Admin/Chronos.Admin.csproj`
- [ ] `dotnet run --project src/Chronos.Admin -- --help` lists `login` and `accounts`
- [ ] First `login` with env bootstrap vars seeds DB, authenticates, writes session file
- [ ] `accounts list` without session → exit **2**, message on stderr
- [ ] `accounts list` after `login` prints table with bootstrap account
- [ ] `accounts add` creates second admin; list shows both rows
- [ ] Invalid login → exit **1**, no password echoed in output
- [ ] Invalid `accounts add` args (e.g. weak password) → exit **3**

## Operator setup (for manual QA)

```powershell
$env:AdminConfiguration__DefaultEmail = "admin@internal.example"
$env:AdminConfiguration__DefaultPassword = "<meets-password-policy>"
$env:AdminConfiguration__SecretKey = "<at-least-32-characters>"
dotnet run --project src/Chronos.Admin -- login --email admin@internal.example --password <password>
dotnet run --project src/Chronos.Admin -- accounts list
```

## Notes for reviewers

- Completes Phase 2 per `docs/Chronos.Admin.md`. Phase 3 (`orgs list` / `orgs show`) and Phase 4 (Docker, CI, tests) are out of scope.
- `accounts add` / `accounts list` require a valid session; `login` does not.
