### PR TITLE
chronos-admin: wire CLI entrypoint and local env

### DIFF
--- a/src/Chronos.Admin/AppSettings/appsettings.json
+++ b/src/Chronos.Admin/AppSettings/appsettings.json
@@ -1,8 +1,15 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "None",
+      "Microsoft.EntityFrameworkCore.Update": "None",
+      "Microsoft.EntityFrameworkCore.Database.Connection": "None",
+      "Microsoft.EntityFrameworkCore.Query": "None",
+      "Microsoft.EntityFrameworkCore.Migrations": "Warning",
+      "Microsoft.Hosting.Lifetime": "Warning"
     }
   },
   "ConnectionStrings": {

--- a/src/Chronos.Admin/Cli/AdminCommandRoot.cs
+++ b/src/Chronos.Admin/Cli/AdminCommandRoot.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using Microsoft.EntityFrameworkCore;
 using Chronos.Admin.Auth.Contracts;
 using Chronos.Admin.Auth.Services;
 using Chronos.Admin.Auth.Session;
@@ -18,9 +19,6 @@ public static class AdminCommandRoot
 
         var emailOption = new Option<string?>("--email", "Platform admin email address.");
         var passwordOption = new Option<string?>("--password", "Password (prompted if omitted).");
-        var firstNameOption = new Option<string>("--first-name", "Account first name.") { IsRequired = true };
-        var lastNameOption = new Option<string>("--last-name", "Account last name.") { IsRequired = true };
-
         var loginCommand = new Command("login", "Sign in and save a session for later commands.");
         loginCommand.AddOption(emailOption);
         loginCommand.AddOption(passwordOption);
@@ -29,6 +27,12 @@ public static class AdminCommandRoot
             var email = context.ParseResult.GetValueForOption(emailOption);
             var password = context.ParseResult.GetValueForOption(passwordOption);
             context.ExitCode = await RunLoginAsync(host, email, password);
+        });
+
+        var logoutCommand = new Command("logout", "Clear the saved admin session on this machine.");
+        logoutCommand.SetHandler(async (InvocationContext context) =>
+        {
+            context.ExitCode = await RunLogoutAsync(host);
         });
 
         var accountsCommand = new Command("accounts", "Manage platform admin accounts.");
@@ -41,15 +45,17 @@ public static class AdminCommandRoot
 
         var accountsAddCommand = new Command("add", "Add a platform admin account.");
         var addEmailArgument = new Argument<string>("email", "Email address for the new account.");
+        var addFirstNameOption = new Option<string>("--first-name", "Account first name.");
+        var addLastNameOption = new Option<string>("--last-name", "Account last name.");
         accountsAddCommand.AddArgument(addEmailArgument);
-        accountsAddCommand.AddOption(firstNameOption);
-        accountsAddCommand.AddOption(lastNameOption);
+        accountsAddCommand.AddOption(addFirstNameOption);
+        accountsAddCommand.AddOption(addLastNameOption);
         accountsAddCommand.AddOption(passwordOption);
         accountsAddCommand.SetHandler(async (InvocationContext context) =>
         {
             var email = context.ParseResult.GetValueForArgument(addEmailArgument);
-            var firstName = context.ParseResult.GetValueForOption(firstNameOption)!;
-            var lastName = context.ParseResult.GetValueForOption(lastNameOption)!;
+            var firstName = context.ParseResult.GetValueForOption(addFirstNameOption);
+            var lastName = context.ParseResult.GetValueForOption(addLastNameOption);
             var password = context.ParseResult.GetValueForOption(passwordOption);
             context.ExitCode = await RunAccountsAddAsync(host, email, firstName, lastName, password);
         });
@@ -58,6 +64,7 @@ public static class AdminCommandRoot
         accountsCommand.AddCommand(accountsAddCommand);
 
         root.AddCommand(loginCommand);
+        root.AddCommand(logoutCommand);
         root.AddCommand(accountsCommand);
 
         return root;
@@ -88,6 +95,14 @@ public static class AdminCommandRoot
         }
     }
 
+    private static async Task<int> RunLogoutAsync(IHost host)
+    {
+        var sessionStore = host.Services.GetRequiredService<IAdminSessionStore>();
+        await sessionStore.ClearAsync();
+        Console.WriteLine("Session cleared.");
+        return AdminExitCodes.Success;
+    }
+
     private static async Task<int> RunAccountsListAsync(IHost host)
     {
         try
@@ -113,12 +128,18 @@ public static class AdminCommandRoot
     private static async Task<int> RunAccountsAddAsync(
         IHost host,
         string email,
-        string firstName,
-        string lastName,
+        string? firstName,
+        string? lastName,
         string? password)
     {
         try
         {
+            if (string.IsNullOrWhiteSpace(firstName) || string.IsNullOrWhiteSpace(lastName))
+            {
+                throw new ArgumentException(
+                    "Both --first-name and --last-name are required. Example: accounts add user@example.com --first-name Jane --last-name Doe --password Secret1");
+            }
+
             password = RequireValue(password, "Password", secret: true);
 
             using var scope = host.Services.CreateScope();
@@ -203,10 +224,23 @@ public static class AdminCommandRoot
         {
             UnauthorizedException => "Invalid credentials.",
             BadRequestException bad => bad.Message,
+            DbUpdateException db when db.InnerException?.Message.Contains("FirstName", StringComparison.OrdinalIgnoreCase) == true
+                => "First name is required. Use --first-name.",
+            DbUpdateException db when db.InnerException?.Message.Contains("LastName", StringComparison.OrdinalIgnoreCase) == true
+                => "Last name is required. Use --last-name.",
+            DbUpdateException db => db.InnerException?.Message ?? db.Message,
             _ => ex.Message
         };
 
-        Console.Error.WriteLine(message);
+        if (ex is AdminSessionRequiredException)
+        {
+            Console.WriteLine(message);
+        }
+        else
+        {
+            Console.Error.WriteLine(message);
+        }
+
         return AdminExitCodes.FromException(ex);
     }
 }

--- a/src/Chronos.Admin/Configuration/LocalEnvLoader.cs
+++ b/src/Chronos.Admin/Configuration/LocalEnvLoader.cs
@@ -1,0 +1,55 @@
+namespace Chronos.Admin.Configuration;
+
+/// <summary>
+/// Loads <c>.local.env</c> from the current directory or parents (same file docker-compose uses).
+/// </summary>
+public static class LocalEnvLoader
+{
+    public static void LoadIfPresent()
+    {
+        var path = FindFile();
+        if (path is null)
+        {
+            return;
+        }
+
+        foreach (var line in File.ReadAllLines(path))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#'))
+            {
+                continue;
+            }
+
+            var separator = trimmed.IndexOf('=');
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var key = trimmed[..separator].Trim();
+            var value = trimmed[(separator + 1)..].Trim().Trim('"');
+            if (key.Length > 0 && Environment.GetEnvironmentVariable(key) is null)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+    }
+
+    private static string? FindFile()
+    {
+        var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, ".local.env");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/src/Chronos.Admin/Program.cs
+++ b/src/Chronos.Admin/Program.cs
@@ -1,4 +1,6 @@
 using Chronos.Admin.Auth;
+using Chronos.Admin.Cli;
+using Chronos.Admin.Configuration;
 using Chronos.Admin.CredStore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +9,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+
+LocalEnvLoader.LoadIfPresent();
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -27,11 +31,5 @@ await using (var scope = host.Services.CreateAsyncScope())
     await db.Database.MigrateAsync();
 }
 
-var rootCommand = new RootCommand("Chronos platform administration CLI.");
-rootCommand.SetHandler(() =>
-{
-    Console.WriteLine("Chronos.Admin — credential store ready (auth commands ship in a later PR).");
-    Console.WriteLine("See docs/Chronos.Admin.md in this project for the design.");
-});
-
+var rootCommand = AdminCommandRoot.Build(host);
 return await rootCommand.Parse(args).InvokeAsync();

--- a/src/Chronos.Admin/README.md
+++ b/src/Chronos.Admin/README.md
@@ -17,6 +17,7 @@ Customer JWTs, org headers, and org-scoped user records are not used for admin a
 | Command | Description |
 |---------|-------------|
 | `login` | Sign in and persist a session for later commands |
+| `logout` | Remove the saved session on this machine |
 | `accounts add` / `accounts list` | Manage platform admin accounts |
 | `orgs list` | All organizations (id, name, admin emails, user count) |
 | `orgs show <id>` | Detail for one organization |
@@ -31,8 +32,11 @@ export AdminConfiguration__DefaultEmail=admin@internal.example
 export AdminConfiguration__DefaultPassword='<strong-password>'
 export AdminConfiguration__SecretKey='<signing-key-at-least-32-chars>'
 
-dotnet run --project src/Chronos.Admin -- login --email admin@internal.example
+dotnet run --project src/Chronos.Admin -- login --email admin@internal.example --password '<password>'
 dotnet run --project src/Chronos.Admin -- accounts list
+# Session is stored at %USERPROFILE%\.chronos-admin\session — later commands reuse it until logout or expiry.
+dotnet run --project src/Chronos.Admin -- logout
+dotnet run --project src/Chronos.Admin -- accounts add ops@internal.example --first-name Ops --last-name User --password OpsPass12
 dotnet run --project src/Chronos.Admin -- --help
 ```
 


### PR DESCRIPTION
## Summary

`main` already ships auth, session, and account commands in `AdminCommandRoot`, but `Program.cs` still printed a placeholder message. This PR connects the host to the real command tree and improves day-to-day local use (`.local.env`, quieter logs, logout, clearer errors).

## Changes

- **Entrypoint** — `Program.cs` calls `AdminCommandRoot.Build(host)` instead of the stub handler.
- **Local configuration** — `LocalEnvLoader` loads `.local.env` from the current directory or parents (same pattern as docker-compose); does not override env vars already set.
- **Logging** — EF/SQL noise reduced in `appsettings.json` so CLI output stays readable.
- **CLI**
  - `logout` clears `%USERPROFILE%\.chronos-admin\session`
  - `accounts add` validates `--first-name` / `--last-name` with clearer errors
  - Auth-required failures print to stdout: `Authentication required. Run login first.`
- **Docs** — README quick start updated (password flag, logout, session note).

## Out of scope

Organization commands and PostgreSQL wiring ship in PR 2 (`PR-02-admin-orgs.md`).

## Test plan

- [ ] From `Chronos.Service`: `dotnet run --project src/Chronos.Admin -- login --email <bootstrap> --password <pwd>`
- [ ] `dotnet run --project src/Chronos.Admin -- accounts list` (uses saved session)
- [ ] `dotnet run --project src/Chronos.Admin -- accounts add user@example.com --first-name Jane --last-name Doe --password Secret1`
- [ ] `dotnet run --project src/Chronos.Admin -- logout`
- [ ] `dotnet run --project src/Chronos.Admin -- accounts list` → only `Authentication required. Run login first.` (no compiler warnings)
