### PR TITLE
chronos-admin: cross-tenant org list and show commands

### DIFF
--- a/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs
+++ b/src/Chronos.Admin/Auth/AdminAuthModuleExtensions.cs
@@ -1,6 +1,7 @@
 using Chronos.Admin.Auth.Services;
 using Chronos.Admin.Auth.Session;
 using Chronos.Admin.CredStore;
+using Chronos.Admin.Organizations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,6 +20,7 @@ public static class AdminAuthModuleExtensions
         services.AddScoped<IAdminBootstrapService, AdminBootstrapService>();
 
         services.AddAdminSession();
+        services.AddAdminOrganizations(configuration);
 
         return services;
     }

--- a/src/Chronos.Admin/Chronos.Admin.csproj
+++ b/src/Chronos.Admin/Chronos.Admin.csproj
@@ -17,6 +17,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />

--- a/src/Chronos.Admin/Cli/AdminCommandRoot.cs
+++ b/src/Chronos.Admin/Cli/AdminCommandRoot.cs
@@ -1,10 +1,12 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Chronos.Admin.Auth.Contracts;
 using Chronos.Admin.Auth.Services;
 using Chronos.Admin.Auth.Session;
 using Chronos.Admin.Cli.Output;
+using Chronos.Admin.Organizations;
 using Chronos.Shared.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -63,9 +65,39 @@ public static class AdminCommandRoot
         accountsCommand.AddCommand(accountsListCommand);
         accountsCommand.AddCommand(accountsAddCommand);
 
+        var jsonOption = new Option<bool>("--json", "Write JSON to stdout.");
+        var includeDeletedOption = new Option<bool>("--include-deleted", "Include soft-deleted organizations.");
+
+        var orgsCommand = new Command("orgs", "Cross-tenant organization views (PostgreSQL).");
+
+        var orgsListCommand = new Command("list", "List all organizations.");
+        orgsListCommand.AddOption(jsonOption);
+        orgsListCommand.AddOption(includeDeletedOption);
+        orgsListCommand.SetHandler(async (InvocationContext context) =>
+        {
+            var json = context.ParseResult.GetValueForOption(jsonOption);
+            var includeDeleted = context.ParseResult.GetValueForOption(includeDeletedOption);
+            context.ExitCode = await RunOrgsListAsync(host, json, includeDeleted);
+        });
+
+        var orgsShowCommand = new Command("show", "Show one organization.");
+        var orgIdArgument = new Argument<string>("organization-id", "Organization GUID.");
+        orgsShowCommand.AddArgument(orgIdArgument);
+        orgsShowCommand.AddOption(jsonOption);
+        orgsShowCommand.SetHandler(async (InvocationContext context) =>
+        {
+            var orgId = context.ParseResult.GetValueForArgument(orgIdArgument);
+            var json = context.ParseResult.GetValueForOption(jsonOption);
+            context.ExitCode = await RunOrgsShowAsync(host, orgId, json);
+        });
+
+        orgsCommand.AddCommand(orgsListCommand);
+        orgsCommand.AddCommand(orgsShowCommand);
+
         root.AddCommand(loginCommand);
         root.AddCommand(logoutCommand);
         root.AddCommand(accountsCommand);
+        root.AddCommand(orgsCommand);
 
         return root;
     }
@@ -161,6 +193,89 @@ public static class AdminCommandRoot
             return WriteError(ex);
         }
     }
+
+    private static async Task<int> RunOrgsListAsync(IHost host, bool json, bool includeDeleted)
+    {
+        try
+        {
+            using var scope = host.Services.CreateScope();
+            await scope.ServiceProvider.GetRequiredService<IAdminSessionGuard>().RequireValidSessionAsync();
+
+            if (!TryGetOrgService(scope.ServiceProvider, out var orgService))
+            {
+                return AdminExitCodes.GeneralError;
+            }
+
+            var organizations = await orgService!.ListOrganizationsAsync(includeDeleted);
+
+            if (json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(organizations, JsonOptions));
+            }
+            else
+            {
+                AdminOrganizationTableWriter.Write(organizations);
+            }
+
+            return AdminExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            return WriteError(ex);
+        }
+    }
+
+    private static async Task<int> RunOrgsShowAsync(IHost host, string organizationId, bool json)
+    {
+        try
+        {
+            if (!Guid.TryParse(organizationId, out var orgGuid))
+            {
+                throw new ArgumentException("organization-id must be a valid GUID.");
+            }
+
+            using var scope = host.Services.CreateScope();
+            await scope.ServiceProvider.GetRequiredService<IAdminSessionGuard>().RequireValidSessionAsync();
+
+            if (!TryGetOrgService(scope.ServiceProvider, out var orgService))
+            {
+                return AdminExitCodes.GeneralError;
+            }
+
+            var organization = await orgService!.GetOrganizationAsync(orgGuid);
+
+            if (json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(organization, JsonOptions));
+            }
+            else
+            {
+                AdminOrganizationTableWriter.Write([organization]);
+            }
+
+            return AdminExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            return WriteError(ex);
+        }
+    }
+
+    private static bool TryGetOrgService(
+        IServiceProvider services,
+        out IAdminOrganizationService? orgService)
+    {
+        orgService = services.GetService<IAdminOrganizationService>();
+        if (orgService is not null)
+        {
+            return true;
+        }
+
+        Console.Error.WriteLine(AdminOrganizationModuleExtensions.GetMissingConnectionMessage());
+        return false;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     private static string RequireValue(string? value, string prompt, bool secret = false)
     {

--- a/src/Chronos.Admin/Cli/AdminExitCodes.cs
+++ b/src/Chronos.Admin/Cli/AdminExitCodes.cs
@@ -9,6 +9,7 @@ public static class AdminExitCodes
     public const int GeneralError = 1;
     public const int AuthenticationRequired = 2;
     public const int InvalidArguments = 3;
+    public const int NotFound = 4;
 
     public static int FromException(Exception ex) =>
         ex switch
@@ -17,6 +18,7 @@ public static class AdminExitCodes
             UnauthorizedException => GeneralError,
             BadRequestException => InvalidArguments,
             ArgumentException => InvalidArguments,
+            NotFoundException => NotFound,
             _ => GeneralError
         };
 }

--- a/src/Chronos.Admin/Cli/Output/AdminOrganizationTableWriter.cs
+++ b/src/Chronos.Admin/Cli/Output/AdminOrganizationTableWriter.cs
@@ -1,0 +1,39 @@
+using Chronos.Admin.Organizations.Contracts;
+
+namespace Chronos.Admin.Cli.Output;
+
+public static class AdminOrganizationTableWriter
+{
+    public static void Write(IReadOnlyList<OrgSummary> organizations)
+    {
+        if (organizations.Count == 0)
+        {
+            Console.WriteLine("No organizations found.");
+            return;
+        }
+
+        var rows = organizations.Select(o => new[]
+        {
+            o.OrganizationId.ToString(),
+            o.Name,
+            string.Join(", ", o.AdminEmails),
+            o.UserCount.ToString(),
+            o.CreatedAt.ToString("u")
+        }).ToList();
+
+        var headers = new[] { "OrganizationId", "Name", "AdminEmails", "UserCount", "Created (UTC)" };
+        var widths = headers.Select((h, i) =>
+            Math.Max(h.Length, rows.Max(r => r[i].Length))).ToArray();
+
+        Console.WriteLine(FormatRow(headers, widths));
+        Console.WriteLine(new string('-', widths.Sum() + (widths.Length - 1) * 2));
+
+        foreach (var row in rows)
+        {
+            Console.WriteLine(FormatRow(row, widths));
+        }
+    }
+
+    private static string FormatRow(string[] cells, int[] widths) =>
+        string.Join("  ", cells.Select((cell, i) => cell.PadRight(widths[i])));
+}

--- a/src/Chronos.Admin/Organizations/AdminOrganizationModuleExtensions.cs
+++ b/src/Chronos.Admin/Organizations/AdminOrganizationModuleExtensions.cs
@@ -1,0 +1,29 @@
+using Chronos.Data.Context;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Chronos.Admin.Organizations;
+
+public static class AdminOrganizationModuleExtensions
+{
+    public static IServiceCollection AddAdminOrganizations(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var connectionString = AdminPostgresConnection.Resolve(configuration);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return services;
+        }
+
+        services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
+        services.AddScoped<IAdminOrganizationService, AdminOrganizationService>();
+
+        return services;
+    }
+
+    public static string GetMissingConnectionMessage() =>
+        "PostgreSQL is required for org commands. Set ConnectionStrings__AdminConnection "
+        + "(Host=localhost) or ConnectionStrings__DefaultConnection in .local.env.";
+}

--- a/src/Chronos.Admin/Organizations/AdminOrganizationService.cs
+++ b/src/Chronos.Admin/Organizations/AdminOrganizationService.cs
@@ -1,0 +1,107 @@
+using Chronos.Admin.Organizations.Contracts;
+using Chronos.Data.Context;
+using Chronos.Domain.Management.Roles;
+using Chronos.Shared.Exceptions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Chronos.Admin.Organizations;
+
+public class AdminOrganizationService(AppDbContext context) : IAdminOrganizationService
+{
+    public async Task<IReadOnlyList<OrgSummary>> ListOrganizationsAsync(
+        bool includeDeleted = false,
+        CancellationToken cancellationToken = default)
+    {
+        var organizations = await context.Organizations
+            .IgnoreQueryFilters()
+            .Where(o => includeDeleted || !o.Deleted)
+            .OrderBy(o => o.Name)
+            .ToListAsync(cancellationToken);
+
+        if (organizations.Count == 0)
+        {
+            return [];
+        }
+
+        var orgIds = organizations.Select(o => o.Id).ToList();
+        var adminEmailsByOrg = await GetAdminEmailsByOrganizationAsync(orgIds, cancellationToken);
+        var userCountsByOrg = await GetUserCountsByOrganizationAsync(orgIds, cancellationToken);
+
+        return organizations
+            .Select(o => new OrgSummary(
+                o.Id,
+                o.Name,
+                adminEmailsByOrg.GetValueOrDefault(o.Id, []),
+                userCountsByOrg.GetValueOrDefault(o.Id, 0),
+                o.CreatedAt))
+            .ToList();
+    }
+
+    public async Task<OrgSummary> GetOrganizationAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        var organization = await context.Organizations
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(o => o.Id == organizationId, cancellationToken);
+
+        if (organization is null)
+        {
+            throw new NotFoundException($"Organization '{organizationId}' was not found.");
+        }
+
+        var adminEmails = await GetAdminEmailsByOrganizationAsync([organizationId], cancellationToken);
+        var userCounts = await GetUserCountsByOrganizationAsync([organizationId], cancellationToken);
+
+        return new OrgSummary(
+            organization.Id,
+            organization.Name,
+            adminEmails.GetValueOrDefault(organizationId, []),
+            userCounts.GetValueOrDefault(organizationId, 0),
+            organization.CreatedAt);
+    }
+
+    private async Task<Dictionary<Guid, List<string>>> GetAdminEmailsByOrganizationAsync(
+        IReadOnlyList<Guid> organizationIds,
+        CancellationToken cancellationToken)
+    {
+        var assignments = await context.RoleAssignments
+            .IgnoreQueryFilters()
+            .Where(ra => organizationIds.Contains(ra.OrganizationId) && ra.Role == Role.Administrator)
+            .Select(ra => new { ra.OrganizationId, ra.UserId })
+            .ToListAsync(cancellationToken);
+
+        if (assignments.Count == 0)
+        {
+            return new Dictionary<Guid, List<string>>();
+        }
+
+        var userIds = assignments.Select(a => a.UserId).Distinct().ToList();
+        var users = await context.Users
+            .IgnoreQueryFilters()
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.Email })
+            .ToListAsync(cancellationToken);
+
+        var emailByUserId = users.ToDictionary(u => u.Id, u => u.Email);
+
+        return assignments
+            .Where(a => emailByUserId.ContainsKey(a.UserId))
+            .GroupBy(a => a.OrganizationId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(a => emailByUserId[a.UserId]).Distinct().OrderBy(e => e).ToList());
+    }
+
+    private async Task<Dictionary<Guid, int>> GetUserCountsByOrganizationAsync(
+        IReadOnlyList<Guid> organizationIds,
+        CancellationToken cancellationToken)
+    {
+        return await context.Users
+            .IgnoreQueryFilters()
+            .Where(u => organizationIds.Contains(u.OrganizationId))
+            .GroupBy(u => u.OrganizationId)
+            .Select(g => new { OrganizationId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.OrganizationId, x => x.Count, cancellationToken);
+    }
+}

--- a/src/Chronos.Admin/Organizations/AdminPostgresConnection.cs
+++ b/src/Chronos.Admin/Organizations/AdminPostgresConnection.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Chronos.Admin.Organizations;
+
+internal static class AdminPostgresConnection
+{
+    /// <summary>
+    /// Resolves PostgreSQL for the Admin CLI. Prefers <c>ConnectionStrings:AdminConnection</c>
+    /// (host machine). Falls back to <c>DefaultConnection</c>, rewriting <c>Host=postgres</c> to
+    /// <c>localhost</c> so the same .local.env works for Docker services and local dotnet run.
+    /// </summary>
+    public static string? Resolve(IConfiguration configuration)
+    {
+        var admin = configuration.GetConnectionString("AdminConnection");
+        if (!string.IsNullOrWhiteSpace(admin))
+        {
+            return admin;
+        }
+
+        var fallback = configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(fallback))
+        {
+            return null;
+        }
+
+        return fallback
+            .Replace("Host=postgres", "Host=localhost", StringComparison.OrdinalIgnoreCase)
+            .Replace("Server=postgres", "Server=localhost", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Chronos.Admin/Organizations/Contracts/OrgSummary.cs
+++ b/src/Chronos.Admin/Organizations/Contracts/OrgSummary.cs
@@ -1,0 +1,8 @@
+namespace Chronos.Admin.Organizations.Contracts;
+
+public record OrgSummary(
+    Guid OrganizationId,
+    string Name,
+    IReadOnlyList<string> AdminEmails,
+    int UserCount,
+    DateTime CreatedAt);

--- a/src/Chronos.Admin/Organizations/IAdminOrganizationService.cs
+++ b/src/Chronos.Admin/Organizations/IAdminOrganizationService.cs
@@ -1,0 +1,12 @@
+using Chronos.Admin.Organizations.Contracts;
+
+namespace Chronos.Admin.Organizations;
+
+public interface IAdminOrganizationService
+{
+    Task<IReadOnlyList<OrgSummary>> ListOrganizationsAsync(
+        bool includeDeleted = false,
+        CancellationToken cancellationToken = default);
+
+    Task<OrgSummary> GetOrganizationAsync(Guid organizationId, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary

Adds cross-tenant organization views for platform operators: PostgreSQL-backed queries and `orgs list` / `orgs show` CLI commands (table + `--json`), building on the wired CLI from PR 1.

## Changes

- **Organizations module** — `AdminOrganizationService`, `OrgSummary` contract, DI registration in `AdminAuthModuleExtensions`.
- **PostgreSQL** — Npgsql + `AppDbContext`; connection via `AdminPostgresConnection`:
  - Prefers `ConnectionStrings:AdminConnection` (local CLI, e.g. `Host=localhost`)
  - Falls back to `ConnectionStrings:DefaultConnection`
  - Rewrites `Host=postgres` → `localhost` for host-machine runs
- **CLI**
  - `orgs list` [--json] [--include-deleted]
  - `orgs show <organization-id>` [--json]
  - Session checked before DB setup (unauthenticated users see only the auth message)
  - Exit code `4` for `NotFoundException`
- **Output** — `AdminOrganizationTableWriter` for tabular results.

## Configuration

For local runs, set in `.local.env` (loaded by PR 1):

```env
ConnectionStrings__AdminConnection=Host=localhost;Port=5432;...
```

Org commands are skipped at DI registration if no connection string is configured; the CLI prints a short setup hint.

## Merge order

1. Merge **PR 1** (`admin-cli-wire`) to `main`.
2. Rebase this branch:

```powershell
git fetch origin
git checkout feature/noamarg/114/admin-orgs
git rebase origin/main
git push --force-with-lease
```

3. Open/update PR against `main` and merge.

## Test plan

- [ ] Postgres reachable on localhost (e.g. `docker-compose up`)
- [ ] `dotnet run --project src/Chronos.Admin -- login ...`
- [ ] `dotnet run --project src/Chronos.Admin -- orgs list`
- [ ] `dotnet run --project src/Chronos.Admin -- orgs list --json`
- [ ] `dotnet run --project src/Chronos.Admin -- orgs show <guid>`
- [ ] Without login: `orgs list` → auth message only
- [ ] Without `AdminConnection`: helpful connection error after login
