### PR TITLE
Added organiztion validation for ResourceAttributeAssignment and fixe…

### DIFF
--- a/src/Chronos.MainApi/Resources/Services/ResourceValidationService.cs
+++ b/src/Chronos.MainApi/Resources/Services/ResourceValidationService.cs
@@ -89,9 +89,9 @@ public class ResourceValidationService(
     {
         var resourceAttributeAssignment = await resourceAttributeAssignmentRepository.GetByIdAsync(resourceId, resourceAttributeId);
 
-        if (resourceAttributeAssignment == null)
+        if (resourceAttributeAssignment == null || resourceAttributeAssignment.OrganizationId != organizationId)
         {
-            logger.LogWarning("Resource attribute assignment not found. ResourceId: {ResourceId}, ResourceAttributeId: {ResourceAttributeId}", resourceId, resourceAttributeId);
+            logger.LogWarning("Resource attribute assignment not found or does not belong to organization. ResourceId: {ResourceId}, ResourceAttributeId: {ResourceAttributeId}, OrganizationId: {OrganizationId}", resourceId, resourceAttributeId, organizationId);
             throw new NotFoundException("Resource attribute assignment not found");
         }
 

--- a/tests/Chronos.Tests.MainApi/Services/Resources/ResourceValidationServiceTests.cs
+++ b/tests/Chronos.Tests.MainApi/Services/Resources/ResourceValidationServiceTests.cs
@@ -127,17 +127,38 @@ public class ResourceValidationServiceTests
     }
 
     [Test]
-    public async Task GivenValidAssignment_WhenValidateAndGetAssignment_ThenReturnsWithoutOrgCheck()
+    public async Task GivenAssignmentInSameOrg_WhenValidateAndGetAssignment_ThenReturnsAssignment()
     {
-        // Documents that assignment validation does NOT check organizationId
+        var orgId = Guid.NewGuid();
         var resourceId = Guid.NewGuid();
         var attrId = Guid.NewGuid();
-        var assignment = new ResourceAttributeAssignment { ResourceId = resourceId, ResourceAttributeId = attrId };
+        var assignment = new ResourceAttributeAssignment
+        {
+            ResourceId = resourceId,
+            ResourceAttributeId = attrId,
+            OrganizationId = orgId
+        };
         _resourceAttributeAssignmentRepository.GetByIdAsync(resourceId, attrId).Returns(assignment);
 
-        var result = await _service.ValidateAndGetResourceAttributeAssignmentAsync(
-            Guid.NewGuid(), resourceId, attrId);
+        var result = await _service.ValidateAndGetResourceAttributeAssignmentAsync(orgId, resourceId, attrId);
 
         Assert.That(result, Is.EqualTo(assignment));
+    }
+
+    [Test]
+    public void GivenAssignmentInDifferentOrg_WhenValidateAndGetAssignment_ThenThrowsNotFound()
+    {
+        var resourceId = Guid.NewGuid();
+        var attrId = Guid.NewGuid();
+        var assignment = new ResourceAttributeAssignment
+        {
+            ResourceId = resourceId,
+            ResourceAttributeId = attrId,
+            OrganizationId = Guid.NewGuid()
+        };
+        _resourceAttributeAssignmentRepository.GetByIdAsync(resourceId, attrId).Returns(assignment);
+
+        Assert.ThrowsAsync<NotFoundException>(() =>
+            _service.ValidateAndGetResourceAttributeAssignmentAsync(Guid.NewGuid(), resourceId, attrId));
     }
 }


### PR DESCRIPTION
## Description

`ResourceValidationService.ValidateAndGetResourceAttributeAssignmentAsync` was the
only one of six entity validators that did not verify the entity belongs to the
caller's organization — it checked for null but ignored `OrganizationId`. This
allowed `Get`/`Update`/`Delete` of another organization's resource-attribute
assignment if the caller knew the `(resourceId, resourceAttributeId)` pair. This
PR adds the org check so the method is consistent with its five sibling validators.

## Related Issues

Closes bgu-nasa/main#127

## Changes Made

- Added `|| resourceAttributeAssignment.OrganizationId != organizationId` to the
  guard in `ValidateAndGetResourceAttributeAssignmentAsync`; updated the warning log.
- Replaced the `...ThenReturnsWithoutOrgCheck` unit test (which asserted the buggy
  behavior) with same-org (returns) and different-org (throws `NotFoundException`) tests.

## Testing

-   [ ] Unit tests added/updated
-   [x] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [ ] Manual testing completed
-   [x] All existing tests pass

### Test Instructions

1. `dotnet test tests/Chronos.Tests.MainApi/Chronos.Tests.MainApi.csproj` → 314 passed.

## Checklist

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [x] My changes generate no new warnings or errors
-   [x] I have added tests that prove my fix is effective
-   [x] New and existing unit tests pass locally with my changes

## Database Changes

-   [x] No database changes

## Configuration Changes

-   [x] No configuration changes required

