### PR TITLE
DepartmentService get departments by organization to prevent leaks

### DIFF
--- a/src/Chronos.MainApi/Management/Services/DepartmentService.cs
+++ b/src/Chronos.MainApi/Management/Services/DepartmentService.cs
@@ -45,9 +45,9 @@ public class DepartmentService(
         await validationService.ValidateOrganizationAsync(organizationId);
 
         var allDepartments = await departmentRepository.GetAllAsync();
-        var filteredDepartments = allDepartments;
-            // .Where(d => d.OrganizationId == organizationId && !d.Deleted)
-            // .ToList();
+        var filteredDepartments = allDepartments
+            .Where(d => d.OrganizationId == organizationId && !d.Deleted)
+            .ToList();
 
         logger.LogDebug("Retrieved {Count} departments for organization. OrganizationId: {OrganizationId}", filteredDepartments.Count, organizationId);
         return filteredDepartments;

--- a/tests/Chronos.Tests.MainApi/Services/Management/DepartmentServiceTests.cs
+++ b/tests/Chronos.Tests.MainApi/Services/Management/DepartmentServiceTests.cs
@@ -63,24 +63,46 @@ public class DepartmentServiceTests
     }
 
     [Test]
-    public async Task GivenAllDepartments_WhenGetDepartments_ThenReturnsUnfilteredList()
+    public async Task GivenDepartmentsAcrossOrgs_WhenGetDepartments_ThenReturnsOnlyThisOrgs()
     {
-        // This test documents the current bug: GetDepartmentsAsync returns
-        // ALL departments because the .Where filter is commented out.
+        // GetAllAsync returns the whole (cross-tenant) departments table;
+        // the service must return only the departments owned by the requested org.
         var orgId = Guid.NewGuid();
         var otherOrgId = Guid.NewGuid();
         SetupValidOrganization(orgId);
 
+        var ownA = new Department { Id = Guid.NewGuid(), OrganizationId = orgId, Deleted = false };
+        var ownB = new Department { Id = Guid.NewGuid(), OrganizationId = orgId, Deleted = false };
         _departmentRepository.GetAllAsync().Returns(new List<Department>
         {
-            new() { Id = Guid.NewGuid(), OrganizationId = orgId, Deleted = false },
+            ownA,
+            new() { Id = Guid.NewGuid(), OrganizationId = otherOrgId, Deleted = false },
+            ownB,
             new() { Id = Guid.NewGuid(), OrganizationId = otherOrgId, Deleted = false },
         });
 
         var result = await _service.GetDepartmentsAsync(orgId);
 
-        // BUG: returns 2 instead of 1 because org filter is commented out
-        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result.Select(d => d.Id), Is.EquivalentTo(new[] { ownA.Id, ownB.Id }));
+    }
+
+    [Test]
+    public async Task GivenDeletedDepartmentInOrg_WhenGetDepartments_ThenExcludesDeleted()
+    {
+        var orgId = Guid.NewGuid();
+        SetupValidOrganization(orgId);
+
+        var activeDept = new Department { Id = Guid.NewGuid(), OrganizationId = orgId, Deleted = false };
+        _departmentRepository.GetAllAsync().Returns(new List<Department>
+        {
+            activeDept,
+            new() { Id = Guid.NewGuid(), OrganizationId = orgId, Deleted = true },
+        });
+
+        var result = await _service.GetDepartmentsAsync(orgId);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Id, Is.EqualTo(activeDept.Id));
     }
 
     [Test]


### PR DESCRIPTION
## Description

`DepartmentService.GetDepartmentsAsync` returned **all** departments across every
organization because its org/deleted filter was commented out. `GET /api/management/department`
therefore leaked other tenants' departments. This PR restores the filter so the
method returns only the caller's organization's non-deleted departments.

## Related Issues

Closes bgu-nasa/main#128

## Changes Made

- Restored `.Where(d => d.OrganizationId == organizationId && !d.Deleted).ToList()`
  in `GetDepartmentsAsync`.
- Replaced the unit test that documented the bug (`...ThenReturnsUnfilteredList`,
  asserting Count == 2) with:
  - `GivenDepartmentsFromMultipleOrgs_...ThenReturnsOnlyThisOrgs`
  - `GivenDeletedDepartmentInOrg_...ThenExcludesDeleted`

## Testing

-   [x] Unit tests added/updated
-   [ ] Integration tests added/updated
-   [ ] Manual testing completed
-   [x] All existing tests pass

### Test Instructions

1. `dotnet test tests/Chronos.Tests.MainApi/...` → 314 passed
2. `dotnet test tests/Chronos.Tests.System/...` → 36 passed (E2E department listing unaffected)

## Checklist

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [x] My changes generate no new warnings or errors
-   [x] I have added tests that prove my fix is effective
-   [x] New and existing unit tests pass locally with my changes

## Database Changes

-   [x] No database changes

## Configuration Changes

-   [x] No configuration changes required
