### PR TITLE
Support files for acceptance tests that setup environment

### DIFF
--- a/tests/Chronos.Tests.Acceptance/Features/OrganizationOnboarding/OrganizationOnboardingTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Features/OrganizationOnboarding/OrganizationOnboardingTests.cs
@@ -1,0 +1,51 @@
+using Chronos.MainApi.Management.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
+using FluentAssertions;
+
+namespace Chronos.Tests.Acceptance.Features.OrganizationOnboarding;
+
+/// <summary>
+/// Acceptance coverage for the organization-onboarding feature: an administrator
+/// registers an organization and can immediately operate within it. Doubles as the
+/// proving ground for the <see cref="AcceptanceContext"/> + <see cref="Seeder"/> helpers.
+/// </summary>
+[TestFixture]
+[Category("Acceptance")]
+public class OrganizationOnboardingTests
+{
+    private const string OrgName = "Onboarding Acceptance Org";
+
+    private AcceptanceContext _ctx = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp() => _ctx = await AcceptanceContext.CreateAsync(OrgName);
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _ctx.Dispose();
+
+    [Test]
+    public async Task GivenRegisteredAdmin_WhenGetOrganizationInfo_ThenReturnsTheirOrganization()
+    {
+        var response = await _ctx.AdminClient.GetAsync("/api/management/organization/info");
+        var info = await response.ReadJsonAsync<OrganizationInformation>();
+
+        info.Should().NotBeNull();
+        info!.Name.Should().Be(OrgName);
+        info.UserEmail.Should().Be(_ctx.AdminEmail);
+        info.Deleted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GivenRegisteredAdmin_WhenCreateDepartment_ThenItAppearsInTheDepartmentList()
+    {
+        var created = await _ctx.Seed.CreateDepartmentAsync("Engineering");
+
+        var list = await (await _ctx.AdminClient.GetAsync("/api/management/department"))
+            .ReadJsonAsync<DepartmentResponse[]>();
+
+        list.Should().NotBeNull();
+        list!.Should().ContainSingle(d => d.Id == created.Id)
+            .Which.Name.Should().Be("Engineering");
+    }
+}

--- a/tests/Chronos.Tests.Acceptance/Flows/Authentication/AuthFlowTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Authentication/AuthFlowTests.cs
@@ -4,7 +4,7 @@ using Chronos.MainApi.Auth.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
 using FluentAssertions;
 
-namespace Chronos.Tests.Acceptance.Flows;
+namespace Chronos.Tests.Acceptance.Flows.Authentication;
 
 [TestFixture]
 [Category("Acceptance")]

--- a/tests/Chronos.Tests.Acceptance/Flows/Authentication/ErrorHandlingTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Authentication/ErrorHandlingTests.cs
@@ -4,7 +4,7 @@ using Chronos.MainApi.Auth.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
 using FluentAssertions;
 
-namespace Chronos.Tests.Acceptance.Flows;
+namespace Chronos.Tests.Acceptance.Flows.Authentication;
 
 [TestFixture]
 [Category("Acceptance")]

--- a/tests/Chronos.Tests.Acceptance/Flows/Authorization/RbacEnforcementTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Authorization/RbacEnforcementTests.cs
@@ -8,7 +8,7 @@ using Chronos.MainApi.Schedule.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
 using FluentAssertions;
 
-namespace Chronos.Tests.Acceptance.Flows;
+namespace Chronos.Tests.Acceptance.Flows.Authorization;
 
 [TestFixture]
 [Category("Acceptance")]

--- a/tests/Chronos.Tests.Acceptance/Flows/Health/HealthTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Health/HealthTests.cs
@@ -3,7 +3,7 @@ using Chronos.Domain.Management.Roles;
 using Chronos.Tests.Acceptance.Infrastructure;
 using FluentAssertions;
 
-namespace Chronos.Tests.Acceptance.Flows;
+namespace Chronos.Tests.Acceptance.Flows.Health;
 
 [TestFixture]
 [Category("Acceptance")]

--- a/tests/Chronos.Tests.Acceptance/Flows/Health/SmokeTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Health/SmokeTests.cs
@@ -1,7 +1,8 @@
 using System.Net;
 using Chronos.Domain.Management.Roles;
+using Chronos.Tests.Acceptance.Infrastructure;
 
-namespace Chronos.Tests.Acceptance.Infrastructure;
+namespace Chronos.Tests.Acceptance.Flows.Health;
 
 [TestFixture]
 [Category("Acceptance")]

--- a/tests/Chronos.Tests.Acceptance/Flows/OrganizationManagement/OrganizationLifecycleTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/OrganizationManagement/OrganizationLifecycleTests.cs
@@ -6,7 +6,7 @@ using Chronos.MainApi.Management.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
 using FluentAssertions;
 
-namespace Chronos.Tests.Acceptance.Flows;
+namespace Chronos.Tests.Acceptance.Flows.OrganizationManagement;
 
 [TestFixture]
 [Category("Acceptance")]

--- a/tests/Chronos.Tests.Acceptance/Flows/OrganizationManagement/OrganizationOnboardingTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/OrganizationManagement/OrganizationOnboardingTests.cs
@@ -3,7 +3,7 @@ using Chronos.Tests.Acceptance.Infrastructure;
 using Chronos.Tests.Acceptance.Support;
 using FluentAssertions;
 
-namespace Chronos.Tests.Acceptance.Features.OrganizationOnboarding;
+namespace Chronos.Tests.Acceptance.Flows.OrganizationManagement;
 
 /// <summary>
 /// Acceptance coverage for the organization-onboarding feature: an administrator

--- a/tests/Chronos.Tests.Acceptance/Flows/Scheduling/SchedulingPipelineTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Scheduling/SchedulingPipelineTests.cs
@@ -7,7 +7,7 @@ using Chronos.Tests.Acceptance.Infrastructure;
 using FluentAssertions;
 using NSubstitute;
 
-namespace Chronos.Tests.Acceptance.Flows;
+namespace Chronos.Tests.Acceptance.Flows.Scheduling;
 
 /// <summary>
 /// End-to-end tests that exercise the full scheduling pipeline:

--- a/tests/Chronos.Tests.Acceptance/Support/AcceptanceContext.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/AcceptanceContext.cs
@@ -1,0 +1,92 @@
+using System.Net.Http.Headers;
+using Chronos.Domain.Management.Roles;
+using Chronos.MainApi.Auth.Contracts;
+using Chronos.MainApi.Management.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+
+namespace Chronos.Tests.Acceptance.Support;
+
+/// <summary>
+/// One-stop fixture for acceptance tests. Boots a fresh API instance, registers a
+/// new organization with an administrator, and exposes an authenticated, org-scoped
+/// <see cref="AdminClient"/> — collapsing the register → token → x-org-id setup into
+/// a single call. Use <see cref="Seed"/> to create domain data through the API.
+/// </summary>
+public sealed class AcceptanceContext : IDisposable
+{
+    public ChronosApiFactory Factory { get; }
+    public HttpClient AdminClient { get; }
+    public Guid OrganizationId { get; }
+    public Guid AdminUserId { get; }
+    public string AdminEmail { get; }
+
+    /// <summary>Seeds domain data through the API as the organization administrator.</summary>
+    public Seeder Seed { get; }
+
+    private AcceptanceContext(
+        ChronosApiFactory factory,
+        HttpClient adminClient,
+        Guid organizationId,
+        Guid adminUserId,
+        string adminEmail)
+    {
+        Factory = factory;
+        AdminClient = adminClient;
+        OrganizationId = organizationId;
+        AdminUserId = adminUserId;
+        AdminEmail = adminEmail;
+        Seed = new Seeder(adminClient);
+    }
+
+    /// <summary>
+    /// Boots the API, registers a new organization + administrator, and returns a
+    /// context whose <see cref="AdminClient"/> is authenticated and scoped to it.
+    /// </summary>
+    public static async Task<AcceptanceContext> CreateAsync(string? organizationName = null)
+    {
+        var factory = new ChronosApiFactory();
+        var client = factory.CreateClient();
+
+        var email = $"admin-{Guid.NewGuid():N}@chronos.test";
+        var register = await client.PostJsonAsync("/api/auth/register", new RegisterRequest(
+            AdminUser: new CreateUserRequest(email, "Acceptance", "Admin", TestConstants.DefaultPassword),
+            OrganizationName: organizationName ?? $"Acceptance Org {Guid.NewGuid():N}",
+            Plan: "free",
+            InviteCode: TestConstants.InviteCode));
+        register.EnsureSuccessStatusCode();
+
+        var auth = await register.ReadJsonAsync<AuthResponse>()
+                   ?? throw new InvalidOperationException("Registration returned no auth token.");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth.Token);
+
+        var info = await (await client.GetAsync("/api/management/organization/info"))
+                       .ReadJsonAsync<OrganizationInformation>()
+                   ?? throw new InvalidOperationException("Could not read organization info after registration.");
+        client.SetOrgHeader(info.Id);
+
+        var adminUserId = info.UserRoles.FirstOrDefault()?.UserId ?? Guid.Empty;
+
+        return new AcceptanceContext(factory, client, info.Id, adminUserId, email);
+    }
+
+    /// <summary>
+    /// Creates an additional client authenticated as a (synthetic) user holding
+    /// <paramref name="role"/> within this organization. Intended for authorization
+    /// scenarios where a specific role's access needs to be exercised.
+    /// </summary>
+    public HttpClient CreateClientAs(Role role, Guid? userId = null, string? email = null)
+    {
+        var id = userId ?? Guid.NewGuid();
+        return Factory.CreateAuthenticatedClient(
+            id,
+            email ?? $"{role}-{id:N}@chronos.test",
+            OrganizationId,
+            new SimpleRoleForToken(role, OrganizationId));
+    }
+
+    public void Dispose()
+    {
+        AdminClient.Dispose();
+        Factory.Dispose();
+    }
+}

--- a/tests/Chronos.Tests.Acceptance/Support/Seeder.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/Seeder.cs
@@ -1,0 +1,20 @@
+using Chronos.MainApi.Management.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+
+namespace Chronos.Tests.Acceptance.Support;
+
+/// <summary>
+/// Creates domain data through the public API and returns the created resources,
+/// so feature tests can read top-to-bottom instead of repeating setup plumbing.
+/// Extend this per feature as new journeys are added.
+/// </summary>
+public sealed class Seeder(HttpClient client)
+{
+    public async Task<DepartmentResponse> CreateDepartmentAsync(string name)
+    {
+        var response = await client.PostJsonAsync("/api/management/department", new DepartmentRequest(name));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<DepartmentResponse>()
+               ?? throw new InvalidOperationException("Create department returned no body.");
+    }
+}

--- a/tests/Chronos.Tests.Acceptance/Support/TestConstants.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/TestConstants.cs
@@ -1,0 +1,13 @@
+namespace Chronos.Tests.Acceptance.Support;
+
+/// <summary>
+/// Shared constants for acceptance tests, centralized so they are defined once.
+/// </summary>
+public static class TestConstants
+{
+    /// <summary>Private-beta invite code accepted by the registration endpoint.</summary>
+    public const string InviteCode = "hih";
+
+    /// <summary>Default password that satisfies the password policy for seeded users.</summary>
+    public const string DefaultPassword = "Passw0rd1";
+}


### PR DESCRIPTION
## Description

Establishes the foundation for acceptance tests on the renamed Chronos.Tests.Acceptance
project, and reorganizes the suite into a single, coherent structure. Adds a Support/
helper layer (register-an-org-and-authenticate in one call, API-driven seeding, shared
constants), consolidates all tests under Flows/ organized by capability, and includes one
sample feature proving the harness. Existing tests are relocated only — no test logic is
rewritten; helper adoption will happen per feature in follow-up PRs.

## Related Issues

Fixes #120

## Changes Made

**Support layer (new)**
- `Support/AcceptanceContext.cs` — boots the API, registers a fresh org + admin, and exposes
  an authenticated, org-scoped `AdminClient`; `CreateClientAs(role)` for authorization
  scenarios; `Seed` for API-driven data setup.
- `Support/Seeder.cs` — creates domain data through the public API and returns it
  (`CreateDepartmentAsync` to start; extended per feature).
- `Support/TestConstants.cs` — centralized invite code + default password.

**Restructure**
- Retired the `Features/` folder; kept `Flows/` as the umbrella with one subfolder per
  capability: `Authentication/`, `Authorization/`, `Health/`, `OrganizationManagement/`, `Scheduling/`.
- Moved `SmokeTests` out of `Infrastructure/` into `Flows/Health/` — `Infrastructure/` is now
  plumbing only (no `[Test]` classes).
- Relocated the existing flow tests into the matching capability subfolders and updated
  namespaces. No test logic changed.

**Sample feature**
- `Flows/OrganizationManagement/OrganizationOnboardingTests.cs` — exercises the helpers with
  real assertions (register → org info matches → create department → appears in list).

## Testing

-   [x] Integration/acceptance tests added/updated
-   [x] All existing tests pass

### Test Instructions

`dotnet test tests/Chronos.Tests.Acceptance/Chronos.Tests.Acceptance.csproj` → 38 passed
(36 relocated + 2 new sample tests).

## Checklist

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [x] My changes generate no new warnings or errors
-   [x] I have added tests that prove the feature works
-   [x] New and existing tests pass locally with my changes

## Database Changes

-   [x] No database changes

## Configuration Changes

-   [x] No configuration changes required
