### PR TITLE
Modified existing schedule acceptance tests and added new tests

### DIFF
--- a/tests/Chronos.Tests.Acceptance/Flows/Scheduling/AssignmentTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Scheduling/AssignmentTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using Chronos.MainApi.Schedule.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
+using FluentAssertions;
+
+namespace Chronos.Tests.Acceptance.Flows.Scheduling;
+
+/// <summary>
+/// Acceptance coverage for assignment management: create, read (by id, filtered list,
+/// by slot / by activity / by slot+resource), update, and delete. Each test uses a
+/// distinct slot + week number so assignments never collide on the shared resource.
+/// </summary>
+[TestFixture]
+[Category("Acceptance")]
+public class AssignmentTests
+{
+    private AcceptanceContext _ctx = null!;
+    private Guid _periodId;
+    private Guid _resourceId;
+    private Guid _activityId;
+    private Guid _assignedUserId;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _ctx = await AcceptanceContext.CreateAsync("Assignment Acceptance Org");
+
+        var dept = await _ctx.Seed.CreateDepartmentAsync("CS");
+        var period = await _ctx.Seed.CreateSchedulingPeriodAsync(
+            "Fall 2026", new DateTime(2026, 9, 1), new DateTime(2027, 1, 31));
+        _periodId = Guid.Parse(period.Id);
+
+        var type = await _ctx.Seed.CreateResourceTypeAsync(_ctx.OrganizationId, "Lecture Hall");
+        var resource = await _ctx.Seed.CreateResourceAsync(_ctx.OrganizationId, type.Id, "Building A", "Hall-101", 200);
+        _resourceId = resource.Id;
+
+        var user = await _ctx.Seed.CreateUserAsync("assign-lecturer@chronos.test");
+        _assignedUserId = Guid.Parse(user.UserId);
+
+        var subject = await _ctx.Seed.CreateSubjectAsync(_ctx.OrganizationId, dept.Id, _periodId, "CS101", "Intro to CS");
+        var activity = await _ctx.Seed.CreateActivityAsync(
+            _ctx.OrganizationId, dept.Id, subject.Id, _assignedUserId, "Lecture", 30, 2);
+        _activityId = activity.Id;
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _ctx.Dispose();
+
+    private async Task<Guid> SeedSlotAsync(int fromHour)
+    {
+        var slot = await _ctx.Seed.CreateSlotAsync(
+            _periodId, WeekDays.Monday, TimeSpan.FromHours(fromHour), TimeSpan.FromHours(fromHour + 2));
+        return Guid.Parse(slot.Id);
+    }
+
+    [Test]
+    public async Task GivenSetup_WhenCreateAssignment_ThenItIsRetrievableById()
+    {
+        var slotId = await SeedSlotAsync(8);
+
+        var created = await _ctx.Seed.CreateAssignmentAsync(slotId, _resourceId, _activityId, weekNum: 1);
+
+        var got = await (await _ctx.AdminClient.GetAsync($"/api/schedule/scheduling/assignments/{created.Id}"))
+            .ReadJsonAsync<AssignmentResponse>();
+        got.Should().NotBeNull();
+        Guid.Parse(got!.SlotId).Should().Be(slotId);
+        Guid.Parse(got.ResourceId).Should().Be(_resourceId);
+        Guid.Parse(got.ActivityId).Should().Be(_activityId);
+        got.WeekNum.Should().Be(1);
+    }
+
+    [Test]
+    public async Task GivenAssignment_WhenListWithFilters_ThenEachFilterReturnsIt()
+    {
+        var slotId = await SeedSlotAsync(10);
+        var created = await _ctx.Seed.CreateAssignmentAsync(slotId, _resourceId, _activityId, weekNum: 2);
+
+        async Task AssertFilterContains(string query)
+        {
+            var list = await (await _ctx.AdminClient.GetAsync($"/api/schedule/scheduling/assignments{query}"))
+                .ReadJsonAsync<AssignmentResponse[]>();
+            list.Should().NotBeNull();
+            list!.Select(a => a.Id).Should().Contain(created.Id,
+                "filter '{0}' should include the created assignment", query);
+        }
+
+        await AssertFilterContains($"?slotId={slotId}");
+        await AssertFilterContains($"?resourceId={_resourceId}");
+        await AssertFilterContains($"?activityId={_activityId}");
+        await AssertFilterContains($"?assignedUserId={_assignedUserId}");
+        await AssertFilterContains($"?schedulingPeriodId={_periodId}");
+    }
+
+    [Test]
+    public async Task GivenAssignment_WhenQueryBySlotActivityAndResource_ThenReturnsIt()
+    {
+        var slotId = await SeedSlotAsync(12);
+        var created = await _ctx.Seed.CreateAssignmentAsync(slotId, _resourceId, _activityId, weekNum: 3);
+
+        var bySlot = await (await _ctx.AdminClient.GetAsync($"/api/schedule/scheduling/slots/{slotId}/assignments"))
+            .ReadJsonAsync<AssignmentResponse[]>();
+        bySlot!.Select(a => a.Id).Should().Contain(created.Id);
+
+        var byActivity = await (await _ctx.AdminClient.GetAsync(
+                $"/api/schedule/scheduling/activities/{_activityId}/assignments"))
+            .ReadJsonAsync<AssignmentResponse[]>();
+        byActivity!.Select(a => a.Id).Should().Contain(created.Id);
+
+        var bySlotAndResource = await (await _ctx.AdminClient.GetAsync(
+                $"/api/schedule/scheduling/slots/{slotId}/resources/{_resourceId}/assignment"))
+            .ReadJsonAsync<AssignmentResponse>();
+        bySlotAndResource.Should().NotBeNull();
+        bySlotAndResource!.Id.Should().Be(created.Id);
+    }
+
+    [Test]
+    public async Task GivenAssignment_WhenUpdatedToAnotherSlot_ThenChangePersists()
+    {
+        var originalSlot = await SeedSlotAsync(14);
+        var created = await _ctx.Seed.CreateAssignmentAsync(originalSlot, _resourceId, _activityId, weekNum: 4);
+
+        var newSlot = await SeedSlotAsync(16);
+        var update = await _ctx.AdminClient.PatchJsonAsync(
+            $"/api/schedule/scheduling/assignments/{created.Id}",
+            new UpdateAssignmentRequest(newSlot, _resourceId, _activityId, WeekNum: 4));
+        update.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var got = await (await _ctx.AdminClient.GetAsync($"/api/schedule/scheduling/assignments/{created.Id}"))
+            .ReadJsonAsync<AssignmentResponse>();
+        Guid.Parse(got!.SlotId).Should().Be(newSlot);
+    }
+
+    [Test]
+    public async Task GivenAssignment_WhenDeleted_ThenItIsGone()
+    {
+        var slotId = await SeedSlotAsync(18);
+        var created = await _ctx.Seed.CreateAssignmentAsync(slotId, _resourceId, _activityId, weekNum: 5);
+
+        var delete = await _ctx.AdminClient.DeleteAsync($"/api/schedule/scheduling/assignments/{created.Id}");
+        delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var getAfter = await _ctx.AdminClient.GetAsync($"/api/schedule/scheduling/assignments/{created.Id}");
+        getAfter.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Chronos.Tests.Acceptance/Flows/Scheduling/SchedulingPipelineTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Scheduling/SchedulingPipelineTests.cs
@@ -1,208 +1,85 @@
 using System.Net;
-using Chronos.MainApi.Auth.Contracts;
-using Chronos.MainApi.Management.Contracts;
+using Chronos.Domain.Schedule.Messages;
 using Chronos.MainApi.Resources.Contracts;
 using Chronos.MainApi.Schedule.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
 using FluentAssertions;
 using NSubstitute;
 
 namespace Chronos.Tests.Acceptance.Flows.Scheduling;
 
 /// <summary>
-/// End-to-end tests that exercise the full scheduling pipeline:
-/// register → create org structure → define resources → create schedule → trigger batch.
+/// Exercises the full scheduling pipeline: build the schedulable setup
+/// (department → period → slots → resource → subject → activity) and trigger a
+/// batch run. Self-seeding via <see cref="AcceptanceContext"/>; no shared ordered state.
 /// </summary>
 [TestFixture]
 [Category("Acceptance")]
 public class SchedulingPipelineTests
 {
-    private const string ValidInviteCode = "hih";
-
-    private ChronosApiFactory _factory = null!;
-    private HttpClient _client = null!;
-    private Guid _orgId;
+    private AcceptanceContext _ctx = null!;
 
     [OneTimeSetUp]
-    public async Task OneTimeSetUp()
-    {
-        _factory = new ChronosApiFactory();
-        _client = _factory.CreateClient();
-
-        var regResponse = await _client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest("sched-admin@chronos.dev", "Schedule", "Admin", "Passw0rd1"),
-                OrganizationName: "Scheduling Pipeline Org",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
-
-        var auth = await regResponse.ReadJsonAsync<AuthResponse>();
-        _client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", auth!.Token);
-
-        var orgInfo = await (await _client.GetAsync("/api/management/organization/info"))
-            .ReadJsonAsync<OrganizationInformation>();
-        _orgId = orgInfo!.Id;
-        _client.DefaultRequestHeaders.Add("x-org-id", _orgId.ToString());
-    }
+    public async Task OneTimeSetUp() => _ctx = await AcceptanceContext.CreateAsync("Scheduling Pipeline Org");
 
     [OneTimeTearDown]
-    public void OneTimeTearDown()
+    public void OneTimeTearDown() => _ctx.Dispose();
+
+    [Test]
+    public async Task GivenFullSetup_WhenTriggerBatchSchedule_ThenAcceptedAndPublishesRequest()
     {
-        _client?.Dispose();
-        _factory?.Dispose();
-    }
+        var dept = await _ctx.Seed.CreateDepartmentAsync("Engineering Faculty");
+        var period = await _ctx.Seed.CreateSchedulingPeriodAsync(
+            "Fall 2026", new DateTime(2026, 9, 1), new DateTime(2027, 1, 31));
+        var periodId = Guid.Parse(period.Id);
 
-    [Test, Order(1)]
-    public async Task GivenAuthenticatedAdmin_WhenCreateDepartment_ThenReturns201()
-    {
-        var response = await _client.PostJsonAsync("/api/management/department",
-            new DepartmentRequest("Engineering Faculty"));
+        await _ctx.Seed.CreateSlotAsync(periodId, WeekDays.Monday, TimeSpan.FromHours(9), TimeSpan.FromHours(11));
+        await _ctx.Seed.CreateSlotAsync(periodId, WeekDays.Wednesday, TimeSpan.FromHours(14), TimeSpan.FromHours(16));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var dept = await response.ReadJsonAsync<DepartmentResponse>();
-        dept!.Name.Should().Be("Engineering Faculty");
-    }
+        var type = await _ctx.Seed.CreateResourceTypeAsync(_ctx.OrganizationId, "Lecture Hall");
+        await _ctx.Seed.CreateResourceAsync(_ctx.OrganizationId, type.Id, "Building A", "Hall-101", 200);
 
-    [Test, Order(2)]
-    public async Task GivenExistingOrg_WhenCreateSchedulingPeriod_ThenReturns201()
-    {
-        var response = await _client.PostJsonAsync("/api/schedule/scheduling/periods",
-            new CreateSchedulingPeriodRequest(
-                "Fall 2026",
-                new DateTime(2026, 9, 1),
-                new DateTime(2027, 1, 31)));
+        var user = await _ctx.Seed.CreateUserAsync("lecturer@chronos.test");
+        var subject = await _ctx.Seed.CreateSubjectAsync(
+            _ctx.OrganizationId, dept.Id, periodId, "CS201", "Data Structures");
+        await _ctx.Seed.CreateActivityAsync(
+            _ctx.OrganizationId, dept.Id, subject.Id, Guid.Parse(user.UserId), "Lecture", 30, 2);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var period = await response.ReadJsonAsync<SchedulingPeriodResponse>();
-        period!.Name.Should().Be("Fall 2026");
-    }
-
-    [Test, Order(3)]
-    public async Task GivenSchedulingPeriod_WhenCreateSlots_ThenReturns201()
-    {
-        var periodsResponse = await _client.GetAsync("/api/schedule/scheduling/periods");
-        var periods = await periodsResponse.ReadJsonAsync<SchedulingPeriodResponse[]>();
-        var periodId = Guid.Parse(periods!.First().Id);
-
-        var mondaySlot = await _client.PostJsonAsync("/api/schedule/scheduling/slots",
-            new CreateSlotRequest(periodId, WeekDays.Monday,
-                TimeSpan.FromHours(9), TimeSpan.FromHours(11)));
-
-        var wednesdaySlot = await _client.PostJsonAsync("/api/schedule/scheduling/slots",
-            new CreateSlotRequest(periodId, WeekDays.Wednesday,
-                TimeSpan.FromHours(14), TimeSpan.FromHours(16)));
-
-        mondaySlot.StatusCode.Should().Be(HttpStatusCode.Created);
-        wednesdaySlot.StatusCode.Should().Be(HttpStatusCode.Created);
-
-        var mondaySlotBody = await mondaySlot.ReadJsonAsync<SlotResponse>();
-        mondaySlotBody!.Weekday.Should().Be(WeekDays.Monday);
-    }
-
-    [Test, Order(4)]
-    public async Task GivenExistingOrg_WhenCreateResourceTypeAndResource_ThenReturns201()
-    {
-        var typeResponse = await _client.PostJsonAsync("/api/resources/resource/types",
-            new CreateResourceTypeRequest(_orgId, "Lecture Hall"));
-        typeResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-
-        var resourceType = await typeResponse.ReadJsonAsync<ResourceTypeResponse>();
-
-        var resourceResponse = await _client.PostJsonAsync("/api/resources/resource",
-            new CreateResourceRequest(_orgId, resourceType!.Id, "Building A", "Hall-101", 200));
-
-        resourceResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var resource = await resourceResponse.ReadJsonAsync<ResourceResponse>();
-        resource!.Identifier.Should().Be("Hall-101");
-        resource.Capacity.Should().Be(200);
-    }
-
-    [Test, Order(5)]
-    public async Task GivenDepartmentAndPeriod_WhenCreateSubjectAndActivity_ThenReturns201()
-    {
-        var depts = await (await _client.GetAsync("/api/management/department"))
-            .ReadJsonAsync<DepartmentResponse[]>();
-        var deptId = depts!.First().Id;
-
-        var periods = await (await _client.GetAsync("/api/schedule/scheduling/periods"))
-            .ReadJsonAsync<SchedulingPeriodResponse[]>();
-        var periodId = Guid.Parse(periods!.First().Id);
-
-        var subjectResponse = await _client.PostJsonAsync(
-            $"/api/department/{deptId}/resources/subjects/Subject",
-            new CreateSubjectRequest(
-                _orgId, deptId, periodId, "CS201", "Data Structures"));
-        subjectResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var subject = await subjectResponse.ReadJsonAsync<SubjectResponse>();
-
-        // Create user to be assigned to the activity
-        var userResponse = await _client.PostJsonAsync("/api/user",
-            new CreateUserRequest("lecturer@chronos.dev", "Prof", "Smith", "Passw0rd2"));
-        var user = await userResponse.ReadJsonAsync<CreateUserResponse>();
-
-        var activityResponse = await _client.PostJsonAsync(
-            $"/api/department/{deptId}/resources/subjects/Subject/{subject!.Id}/activities",
-            new CreateActivityRequest(_orgId, subject.Id,
-                Guid.Parse(user!.UserId), "Lecture", 120, 2));
-
-        activityResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var activity = await activityResponse.ReadJsonAsync<ActivityResponse>();
-        activity!.ActivityType.Should().Be("Lecture");
-        activity.Duration.Should().Be(2);
-    }
-
-    [Test, Order(6)]
-    public async Task GivenFullDataSetup_WhenTriggerBatchScheduling_ThenReturns202AndPublishesMessage()
-    {
-        var periods = await (await _client.GetAsync("/api/schedule/scheduling/periods"))
-            .ReadJsonAsync<SchedulingPeriodResponse[]>();
-        var periodId = Guid.Parse(periods!.First().Id);
-
-        var response = await _client.PostAsync(
+        var response = await _ctx.AdminClient.PostAsync(
             $"/api/schedule/scheduling/periods/{periodId}/batch-schedule", null);
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("submitted successfully");
-
-        await _factory.MockMessagePublisher.Received(1)
-            .PublishAsync(
-                Arg.Is<Chronos.Domain.Schedule.Messages.SchedulePeriodRequest>(
-                    r => r.SchedulingPeriodId == periodId && r.OrganizationId == _orgId),
-                Arg.Is("request.batch"));
+        await _ctx.Factory.MockMessagePublisher.Received(1).PublishAsync(
+            Arg.Is<SchedulePeriodRequest>(r =>
+                r.SchedulingPeriodId == periodId && r.OrganizationId == _ctx.OrganizationId),
+            "request.batch");
     }
 
-    [Test, Order(7)]
-    public async Task GivenCreatedData_WhenQueryAllSlots_ThenReturnsSlotsList()
+    [Test]
+    public async Task GivenSchedulingSetup_WhenQuerySlotsAndActivities_ThenReturnsSeededData()
     {
-        var response = await _client.GetAsync("/api/schedule/scheduling/slots");
+        var dept = await _ctx.Seed.CreateDepartmentAsync("Science Faculty");
+        var period = await _ctx.Seed.CreateSchedulingPeriodAsync(
+            "Spring 2027", new DateTime(2027, 2, 1), new DateTime(2027, 6, 30));
+        var periodId = Guid.Parse(period.Id);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var slots = await response.ReadJsonAsync<SlotResponse[]>();
+        var slot = await _ctx.Seed.CreateSlotAsync(periodId, WeekDays.Wednesday, TimeSpan.FromHours(10), TimeSpan.FromHours(12));
+        var user = await _ctx.Seed.CreateUserAsync("prof-readback@chronos.test");
+        var subject = await _ctx.Seed.CreateSubjectAsync(_ctx.OrganizationId, dept.Id, periodId, "PHY101", "Physics");
+        var activity = await _ctx.Seed.CreateActivityAsync(
+            _ctx.OrganizationId, dept.Id, subject.Id, Guid.Parse(user.UserId), "Lab", 25, 3);
+
+        var slots = await (await _ctx.AdminClient.GetAsync($"/api/schedule/scheduling/periods/{periodId}/slots"))
+            .ReadJsonAsync<SlotResponse[]>();
         slots.Should().NotBeNull();
-        slots!.Length.Should().BeGreaterThanOrEqualTo(2);
-    }
+        slots!.Select(s => s.Id).Should().Contain(slot.Id);
 
-    [Test, Order(8)]
-    public async Task GivenCreatedData_WhenQueryActivitiesBySubject_ThenReturnsActivities()
-    {
-        var depts = await (await _client.GetAsync("/api/management/department"))
-            .ReadJsonAsync<DepartmentResponse[]>();
-        var deptId = depts!.First().Id;
-
-        var subjects = await (await _client.GetAsync(
-                $"/api/department/{deptId}/resources/subjects/Subject"))
-            .ReadJsonAsync<SubjectResponse[]>();
-        var subjectId = subjects!.First().Id;
-
-        var response = await _client.GetAsync(
-            $"/api/department/{deptId}/resources/subjects/Subject/{subjectId}/activities");
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var activities = await response.ReadJsonAsync<ActivityResponse[]>();
+        var activities = await (await _ctx.AdminClient.GetAsync(
+                $"/api/department/{dept.Id}/resources/subjects/Subject/{subject.Id}/activities"))
+            .ReadJsonAsync<ActivityResponse[]>();
         activities.Should().NotBeNull();
-        activities!.Length.Should().BeGreaterThanOrEqualTo(1);
-        activities.First().ActivityType.Should().Be("Lecture");
+        activities!.Should().ContainSingle(a => a.Id == activity.Id)
+            .Which.ActivityType.Should().Be("Lab");
     }
 }

--- a/tests/Chronos.Tests.Acceptance/Support/Seeder.Scheduling.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/Seeder.Scheduling.cs
@@ -1,0 +1,81 @@
+using Chronos.MainApi.Resources.Contracts;
+using Chronos.MainApi.Schedule.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+
+namespace Chronos.Tests.Acceptance.Support;
+
+/// <summary>
+/// Seed helpers for building a schedulable setup: scheduling period, slots,
+/// resources, subjects, activities, and assignments.
+/// </summary>
+public sealed partial class Seeder
+{
+    public async Task<SchedulingPeriodResponse> CreateSchedulingPeriodAsync(string name, DateTime fromDate, DateTime toDate)
+    {
+        var response = await client.PostJsonAsync("/api/schedule/scheduling/periods",
+            new CreateSchedulingPeriodRequest(name, fromDate, toDate));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<SchedulingPeriodResponse>()
+               ?? throw new InvalidOperationException("Create scheduling period returned no body.");
+    }
+
+    public async Task<SlotResponse> CreateSlotAsync(Guid schedulingPeriodId, WeekDays weekday, TimeSpan fromTime, TimeSpan toTime)
+    {
+        var response = await client.PostJsonAsync("/api/schedule/scheduling/slots",
+            new CreateSlotRequest(schedulingPeriodId, weekday, fromTime, toTime));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<SlotResponse>()
+               ?? throw new InvalidOperationException("Create slot returned no body.");
+    }
+
+    public async Task<ResourceTypeResponse> CreateResourceTypeAsync(Guid organizationId, string type)
+    {
+        var response = await client.PostJsonAsync("/api/resources/resource/types",
+            new CreateResourceTypeRequest(organizationId, type));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<ResourceTypeResponse>()
+               ?? throw new InvalidOperationException("Create resource type returned no body.");
+    }
+
+    public async Task<ResourceResponse> CreateResourceAsync(
+        Guid organizationId, Guid resourceTypeId, string location, string identifier, int? capacity)
+    {
+        var response = await client.PostJsonAsync("/api/resources/resource",
+            new CreateResourceRequest(organizationId, resourceTypeId, location, identifier, capacity));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<ResourceResponse>()
+               ?? throw new InvalidOperationException("Create resource returned no body.");
+    }
+
+    public async Task<SubjectResponse> CreateSubjectAsync(
+        Guid organizationId, Guid departmentId, Guid schedulingPeriodId, string code, string name)
+    {
+        var response = await client.PostJsonAsync(
+            $"/api/department/{departmentId}/resources/subjects/Subject",
+            new CreateSubjectRequest(organizationId, departmentId, schedulingPeriodId, code, name));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<SubjectResponse>()
+               ?? throw new InvalidOperationException("Create subject returned no body.");
+    }
+
+    public async Task<ActivityResponse> CreateActivityAsync(
+        Guid organizationId, Guid departmentId, Guid subjectId, Guid assignedUserId,
+        string activityType, int? expectedStudents, int duration)
+    {
+        var response = await client.PostJsonAsync(
+            $"/api/department/{departmentId}/resources/subjects/Subject/{subjectId}/activities",
+            new CreateActivityRequest(organizationId, subjectId, assignedUserId, activityType, expectedStudents, duration));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<ActivityResponse>()
+               ?? throw new InvalidOperationException("Create activity returned no body.");
+    }
+
+    public async Task<AssignmentResponse> CreateAssignmentAsync(Guid slotId, Guid resourceId, Guid activityId, int weekNum)
+    {
+        var response = await client.PostJsonAsync("/api/schedule/scheduling/assignments",
+            new CreateAssignmentRequest(slotId, resourceId, activityId, weekNum));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<AssignmentResponse>()
+               ?? throw new InvalidOperationException("Create assignment returned no body.");
+    }
+}

--- a/tests/Chronos.Tests.Acceptance/Support/Seeder.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/Seeder.cs
@@ -1,3 +1,4 @@
+using Chronos.MainApi.Auth.Contracts;
 using Chronos.MainApi.Management.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
 
@@ -6,9 +7,9 @@ namespace Chronos.Tests.Acceptance.Support;
 /// <summary>
 /// Creates domain data through the public API and returns the created resources,
 /// so feature tests can read top-to-bottom instead of repeating setup plumbing.
-/// Extend this per feature as new journeys are added.
+/// Feature-specific seed methods live in partial files (e.g. Seeder.Scheduling.cs).
 /// </summary>
-public sealed class Seeder(HttpClient client)
+public sealed partial class Seeder(HttpClient client)
 {
     public async Task<DepartmentResponse> CreateDepartmentAsync(string name)
     {
@@ -16,5 +17,15 @@ public sealed class Seeder(HttpClient client)
         response.EnsureSuccessStatusCode();
         return await response.ReadJsonAsync<DepartmentResponse>()
                ?? throw new InvalidOperationException("Create department returned no body.");
+    }
+
+    public async Task<CreateUserResponse> CreateUserAsync(
+        string email, string firstName = "Test", string lastName = "User", string? password = null)
+    {
+        var response = await client.PostJsonAsync("/api/user",
+            new CreateUserRequest(email, firstName, lastName, password ?? TestConstants.DefaultPassword));
+        response.EnsureSuccessStatusCode();
+        return await response.ReadJsonAsync<CreateUserResponse>()
+               ?? throw new InvalidOperationException("Create user returned no body.");
     }
 }


### PR DESCRIPTION
## Description

Adds the Scheduling acceptance feature on top of the Support helpers, and migrates the
existing scheduling pipeline test onto them. Extends Seeder (now partial, per-feature files)
with the full schedulable-setup chain, replaces the order-dependent [Order(1..8)]
SchedulingPipelineTests with self-seeding tests, and adds end-to-end coverage for the
assignment endpoints (previously untested).

## Related Issues

Closes bgu-nasa/main#121

## Changes Made

- `Support/Seeder.cs` → `partial`, added `CreateUserAsync`.
- `Support/Seeder.Scheduling.cs` (new) → period / slot / resource-type / resource / subject /
  activity / assignment seeders.
- `Flows/Scheduling/SchedulingPipelineTests.cs` → rewritten onto AcceptanceContext+Seeder
  (no [Order]/shared state); asserts 202 + published SchedulePeriodRequest on `request.batch`.
- `Flows/Scheduling/AssignmentTests.cs` (new) → create / get-by-id / filtered list (5 filters) /
  by-slot / by-activity / by-slot+resource / update / delete.

## Testing

-   [x] Acceptance tests added/updated
-   [x] All existing tests pass

### Test Instructions

`dotnet test tests/Chronos.Tests.Acceptance/...` → 37 passed.

## Checklist

-   [x] Self-reviewed
-   [x] No new warnings or errors
-   [x] New and existing tests pass locally

## Database Changes
-   [x] No database changes

## Configuration Changes
-   [x] No configuration changes required

## Additional Context

`Seeder` is split into partial files per feature so the remaining feature PRs (Constraints,
Appeals, User/Role) can extend it without merge conflicts. Assignment tests give each
assignment a distinct slot + WeekNum to avoid the resource double-booking validation.
