### PR TITLE
Modified existing tests to use AcceptanceContext and seeder

### DIFF
--- a/tests/Chronos.Tests.Acceptance/Flows/Authentication/AuthFlowTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Authentication/AuthFlowTests.cs
@@ -1,17 +1,21 @@
 using System.Net;
-using System.Net.Http.Json;
 using Chronos.MainApi.Auth.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
 using FluentAssertions;
 
 namespace Chronos.Tests.Acceptance.Flows.Authentication;
 
+/// <summary>
+/// Exercises the public auth flow (register, login, refresh) end-to-end against
+/// a fresh API instance. These tests deliberately avoid <see cref="AcceptanceContext"/>
+/// because <see cref="AcceptanceContext"/> itself depends on the register flow
+/// working; using the raw factory keeps the assertions on the flow under test.
+/// </summary>
 [TestFixture]
 [Category("Acceptance")]
 public class AuthFlowTests
 {
-    private const string ValidInviteCode = "hih";
-
     private ChronosApiFactory _factory = null!;
 
     [OneTimeSetUp]
@@ -20,17 +24,20 @@ public class AuthFlowTests
     [OneTimeTearDown]
     public void OneTimeTearDown() => _factory.Dispose();
 
+    private static RegisterRequest Register(string email, string orgName, string? password = null) =>
+        new(
+            AdminUser: new CreateUserRequest(email, "Test", "User", password ?? TestConstants.DefaultPassword),
+            OrganizationName: orgName,
+            Plan: "free",
+            InviteCode: TestConstants.InviteCode);
+
     [Test]
     public async Task GivenValidRegistration_WhenRegister_ThenReturnsJwtToken()
     {
         var client = _factory.CreateClient();
-        var request = new RegisterRequest(
-            AdminUser: new CreateUserRequest("reg-test@chronos.dev", "Admin", "User", "Passw0rd1"),
-            OrganizationName: "Auth Test Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode);
 
-        var response = await client.PostJsonAsync("/api/auth/register", request);
+        var response = await client.PostJsonAsync("/api/auth/register",
+            Register("reg-test@chronos.dev", "Auth Test Org"));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var auth = await response.ReadJsonAsync<AuthResponse>();
@@ -44,16 +51,11 @@ public class AuthFlowTests
     {
         var client = _factory.CreateClient();
         var email = "login-test@chronos.dev";
-        var password = "Passw0rd2";
 
-        await client.PostJsonAsync("/api/auth/register", new RegisterRequest(
-            AdminUser: new CreateUserRequest(email, "Login", "Tester", password),
-            OrganizationName: "Login Test Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode));
+        await client.PostJsonAsync("/api/auth/register", Register(email, "Login Test Org"));
 
         var loginResponse = await client.PostJsonAsync("/api/auth/login",
-            new LoginRequest(email, password));
+            new LoginRequest(email, TestConstants.DefaultPassword));
 
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var auth = await loginResponse.ReadJsonAsync<AuthResponse>();
@@ -66,11 +68,7 @@ public class AuthFlowTests
         var client = _factory.CreateClient();
         var email = "wrong-pw@chronos.dev";
 
-        await client.PostJsonAsync("/api/auth/register", new RegisterRequest(
-            AdminUser: new CreateUserRequest(email, "Wrong", "Pw", "Passw0rd3"),
-            OrganizationName: "WrongPw Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode));
+        await client.PostJsonAsync("/api/auth/register", Register(email, "WrongPw Org"));
 
         var loginResponse = await client.PostJsonAsync("/api/auth/login",
             new LoginRequest(email, "TotallyWr0ng"));
@@ -82,17 +80,11 @@ public class AuthFlowTests
     public async Task GivenAuthenticatedUser_WhenRefreshToken_ThenReturnsNewToken()
     {
         var client = _factory.CreateClient();
-        var email = "refresh-test@chronos.dev";
 
-        var regResponse = await client.PostJsonAsync("/api/auth/register", new RegisterRequest(
-            AdminUser: new CreateUserRequest(email, "Refresh", "Tester", "Passw0rd4"),
-            OrganizationName: "Refresh Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode));
-
+        var regResponse = await client.PostJsonAsync("/api/auth/register",
+            Register("refresh-test@chronos.dev", "Refresh Org"));
         var originalAuth = await regResponse.ReadJsonAsync<AuthResponse>();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", originalAuth!.Token);
+        client.UseBearerToken(originalAuth!.Token);
 
         var refreshResponse = await client.PostAsync("/api/auth/refresh", null);
 
@@ -105,8 +97,7 @@ public class AuthFlowTests
     public async Task GivenInvalidToken_WhenAccessProtectedEndpoint_ThenReturns401()
     {
         var client = _factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "invalid.jwt.token");
+        client.UseBearerToken("invalid.jwt.token");
 
         var response = await client.PostAsync("/api/auth/refresh", null);
 

--- a/tests/Chronos.Tests.Acceptance/Flows/Authentication/ErrorHandlingTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Authentication/ErrorHandlingTests.cs
@@ -2,16 +2,21 @@ using System.Net;
 using Chronos.Domain.Management.Roles;
 using Chronos.MainApi.Auth.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
 using FluentAssertions;
 
 namespace Chronos.Tests.Acceptance.Flows.Authentication;
 
+/// <summary>
+/// Covers the validation and error-path branches of the public surface — duplicate
+/// email, weak password, malformed email, missing org header, bad invite code, and
+/// 404s for unknown resources. Uses the raw factory rather than <see cref="AcceptanceContext"/>
+/// because most cases need to exercise the register flow directly with bad inputs.
+/// </summary>
 [TestFixture]
 [Category("Acceptance")]
 public class ErrorHandlingTests
 {
-    private const string ValidInviteCode = "hih";
-
     private ChronosApiFactory _factory = null!;
 
     [OneTimeSetUp]
@@ -19,6 +24,13 @@ public class ErrorHandlingTests
 
     [OneTimeTearDown]
     public void OneTimeTearDown() => _factory.Dispose();
+
+    private static RegisterRequest Register(string email, string orgName, string? password = null, string? inviteCode = null) =>
+        new(
+            AdminUser: new CreateUserRequest(email, "Test", "User", password ?? TestConstants.DefaultPassword),
+            OrganizationName: orgName,
+            Plan: "free",
+            InviteCode: inviteCode ?? TestConstants.InviteCode);
 
     [Test]
     public async Task GivenNonexistentResourceId_WhenGetById_ThenReturns404()
@@ -38,20 +50,11 @@ public class ErrorHandlingTests
     {
         var client = _factory.CreateClient();
         var email = "duplicate@chronos.dev";
-        var request = new RegisterRequest(
-            AdminUser: new CreateUserRequest(email, "Dup", "User", "Passw0rd1"),
-            OrganizationName: "Dup Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode);
 
-        await client.PostJsonAsync("/api/auth/register", request);
+        await client.PostJsonAsync("/api/auth/register", Register(email, "Dup Org"));
 
         var secondResponse = await client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest(email, "Dup", "Again", "Passw0rd2"),
-                OrganizationName: "Dup Org 2",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
+            Register(email, "Dup Org 2"));
 
         secondResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await secondResponse.Content.ReadAsStringAsync();
@@ -62,13 +65,9 @@ public class ErrorHandlingTests
     public async Task GivenWeakPassword_WhenRegister_ThenReturns400WithValidationMessage()
     {
         var client = _factory.CreateClient();
-        var request = new RegisterRequest(
-            AdminUser: new CreateUserRequest("weak-pw@chronos.dev", "Weak", "Pw", "short"),
-            OrganizationName: "Weak Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode);
 
-        var response = await client.PostJsonAsync("/api/auth/register", request);
+        var response = await client.PostJsonAsync("/api/auth/register",
+            Register("weak-pw@chronos.dev", "Weak Org", password: "short"));
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
@@ -79,13 +78,9 @@ public class ErrorHandlingTests
     public async Task GivenInvalidEmail_WhenRegister_ThenReturns400()
     {
         var client = _factory.CreateClient();
-        var request = new RegisterRequest(
-            AdminUser: new CreateUserRequest("not-an-email", "Bad", "Email", "Passw0rd1"),
-            OrganizationName: "Bad Email Org",
-            Plan: "free",
-            InviteCode: ValidInviteCode);
 
-        var response = await client.PostJsonAsync("/api/auth/register", request);
+        var response = await client.PostJsonAsync("/api/auth/register",
+            Register("not-an-email", "Bad Email Org"));
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
@@ -99,8 +94,7 @@ public class ErrorHandlingTests
         var token = TestTokenGenerator.GenerateToken(
             Guid.NewGuid(), "no-org@test.com", Guid.NewGuid(),
             new SimpleRoleForToken(Role.Administrator, Guid.NewGuid()));
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        client.UseBearerToken(token);
 
         var response = await client.GetAsync("/api/user");
 
@@ -113,13 +107,9 @@ public class ErrorHandlingTests
     public async Task GivenInvalidInviteCode_WhenRegister_ThenReturns401()
     {
         var client = _factory.CreateClient();
-        var request = new RegisterRequest(
-            AdminUser: new CreateUserRequest("bad-invite@chronos.dev", "Bad", "Invite", "Passw0rd1"),
-            OrganizationName: "Bad Invite Org",
-            Plan: "free",
-            InviteCode: "invalidcode");
 
-        var response = await client.PostJsonAsync("/api/auth/register", request);
+        var response = await client.PostJsonAsync("/api/auth/register",
+            Register("bad-invite@chronos.dev", "Bad Invite Org", inviteCode: "invalidcode"));
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         var body = await response.Content.ReadAsStringAsync();

--- a/tests/Chronos.Tests.Acceptance/Flows/Authorization/RbacEnforcementTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Authorization/RbacEnforcementTests.cs
@@ -1,49 +1,43 @@
 using System.Net;
-using Chronos.Data.Context;
-using Chronos.Domain.Management;
 using Chronos.Domain.Management.Roles;
-using Chronos.Domain.Resources;
 using Chronos.MainApi.Resources.Contracts;
 using Chronos.MainApi.Schedule.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
 using FluentAssertions;
 
 namespace Chronos.Tests.Acceptance.Flows.Authorization;
 
+/// <summary>
+/// Spot-checks RBAC policy enforcement on representative endpoints: that role-bearing
+/// tokens get through, unauthenticated requests are rejected, and a resource owned by
+/// one organization is invisible from another. Builds prerequisite domain data through
+/// the public API (<see cref="Seeder"/>) so the tests exercise the same authorization
+/// chain users hit in production.
+/// </summary>
 [TestFixture]
 [Category("Acceptance")]
 public class RbacEnforcementTests
 {
-    private ChronosApiFactory _factory = null!;
-    private Guid _orgId;
-    private Guid _deptId;
-    private Guid _userId;
+    private AcceptanceContext _ctx = null!;
     private Guid _resourceTypeId;
 
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
     {
-        _factory = new ChronosApiFactory();
-        _orgId = Guid.NewGuid();
-        _deptId = Guid.NewGuid();
-        _userId = Guid.NewGuid();
-        _resourceTypeId = Guid.NewGuid();
+        _ctx = await AcceptanceContext.CreateAsync("RBAC Test Org");
 
-        // Force the host to start, then seed data
-        _ = _factory.CreateClient();
-
-        await SeedBaseData();
+        var resourceType = await _ctx.Seed.CreateResourceTypeAsync(_ctx.OrganizationId, "Classroom");
+        _resourceTypeId = resourceType.Id;
     }
 
     [OneTimeTearDown]
-    public void OneTimeTearDown() => _factory.Dispose();
+    public void OneTimeTearDown() => _ctx.Dispose();
 
     [Test]
     public async Task GivenViewerRole_WhenGetResources_ThenReturns200()
     {
-        var client = _factory.CreateAuthenticatedClient(
-            _userId, "viewer@rbac.dev", _orgId,
-            new SimpleRoleForToken(Role.Viewer, _orgId));
+        var client = _ctx.CreateClientAs(Role.Viewer);
 
         var response = await client.GetAsync("/api/resources/resource");
 
@@ -53,11 +47,11 @@ public class RbacEnforcementTests
     [Test]
     public async Task GivenUnauthenticatedClient_WhenCreateResource_ThenReturns401()
     {
-        var client = _factory.CreateClient();
+        var client = _ctx.Factory.CreateClient();
 
         var response = await client.PostJsonAsync("/api/resources/resource",
             new CreateResourceRequest(
-                _orgId, _resourceTypeId, "B1-101", "Room-V", 30));
+                _ctx.OrganizationId, _resourceTypeId, "B1-101", "Room-V", 30));
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -65,12 +59,10 @@ public class RbacEnforcementTests
     [Test]
     public async Task GivenResourceManagerRole_WhenCreateResourceType_ThenReturns201()
     {
-        var client = _factory.CreateAuthenticatedClient(
-            _userId, "manager@rbac.dev", _orgId,
-            new SimpleRoleForToken(Role.ResourceManager, _orgId));
+        var client = _ctx.CreateClientAs(Role.ResourceManager);
 
         var response = await client.PostJsonAsync("/api/resources/resource/types",
-            new CreateResourceTypeRequest(_orgId, "Lab"));
+            new CreateResourceTypeRequest(_ctx.OrganizationId, "Lab"));
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var body = await response.ReadJsonAsync<ResourceTypeResponse>();
@@ -80,14 +72,12 @@ public class RbacEnforcementTests
     [Test]
     public async Task GivenOperatorRole_WhenCreateActivityConstraint_ThenReturns201()
     {
-        var activityId = await SeedActivityForConstraintTest();
+        var activity = await _ctx.Seed.CreateActivityWithPrerequisitesAsync(_ctx.OrganizationId);
 
-        var client = _factory.CreateAuthenticatedClient(
-            _userId, "operator@rbac.dev", _orgId,
-            new SimpleRoleForToken(Role.Operator, _orgId));
+        var client = _ctx.CreateClientAs(Role.Operator);
 
         var response = await client.PostJsonAsync("/api/schedule/constraints/activityConstraint",
-            new CreateActivityConstraintRequest(activityId, "maxStudents", "50"));
+            new CreateActivityConstraintRequest(activity.Id, "maxStudents", "50"));
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
     }
@@ -95,9 +85,7 @@ public class RbacEnforcementTests
     [Test]
     public async Task GivenAuthenticatedUser_WhenDeleteNonexistentResource_ThenReturns404()
     {
-        var client = _factory.CreateAuthenticatedClient(
-            _userId, "manager@rbac.dev", _orgId,
-            new SimpleRoleForToken(Role.ResourceManager, _orgId));
+        var client = _ctx.CreateClientAs(Role.ResourceManager);
 
         var response = await client.DeleteAsync($"/api/resources/resource/{Guid.NewGuid()}");
 
@@ -105,109 +93,17 @@ public class RbacEnforcementTests
     }
 
     [Test]
-    public async Task GivenDifferentOrg_WhenAccessOtherOrgResource_ThenResourceNotVisible()
+    public async Task GivenDifferentOrg_WhenAccessOtherOrgResource_ThenReturns404()
     {
-        var managerClient = _factory.CreateAuthenticatedClient(
-            _userId, "manager@rbac.dev", _orgId,
-            new SimpleRoleForToken(Role.ResourceManager, _orgId));
+        var createdResource = await _ctx.Seed.CreateResourceAsync(
+            _ctx.OrganizationId, _resourceTypeId, "B2-200", "Room-Orig", 40);
 
-        var resourceId = Guid.NewGuid();
-        await managerClient.PostJsonAsync("/api/resources/resource",
-            new CreateResourceRequest(_orgId, _resourceTypeId, "B2-200", "Room-Orig", 40));
+        using var otherCtx = await AcceptanceContext.CreateAsync(_ctx.Factory, "Other RBAC Org");
 
-        var otherOrgId = Guid.NewGuid();
-        var otherClient = _factory.CreateAuthenticatedClient(
-            Guid.NewGuid(), "other@rbac.dev", otherOrgId,
-            new SimpleRoleForToken(Role.Viewer, otherOrgId));
+        var response = await otherCtx.AdminClient.GetAsync(
+            $"/api/resources/resource/{createdResource.Id}");
 
-        var response = await otherClient.GetAsync($"/api/resources/resource/{resourceId}");
-
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-    }
-
-    private async Task SeedBaseData()
-    {
-        var (scope, db) = _factory.GetDbContext();
-        using (scope)
-        {
-            db.Set<Organization>().Add(new Organization
-            {
-                Id = _orgId,
-                Name = "RBAC Test Org",
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            });
-
-            db.Set<Department>().Add(new Department
-            {
-                Id = _deptId,
-                OrganizationId = _orgId,
-                Name = "RBAC Dept",
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            });
-
-            db.Set<ResourceType>().Add(new ResourceType
-            {
-                Id = _resourceTypeId,
-                OrganizationId = _orgId,
-                Type = "Classroom",
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            });
-
-            await db.SaveChangesAsync();
-        }
-    }
-
-    private async Task<Guid> SeedActivityForConstraintTest()
-    {
-        var periodId = Guid.NewGuid();
-        var subjectId = Guid.NewGuid();
-        var activityId = Guid.NewGuid();
-
-        var (scope, db) = _factory.GetDbContext();
-        using (scope)
-        {
-            db.Set<Chronos.Domain.Schedule.SchedulingPeriod>().Add(
-                new Chronos.Domain.Schedule.SchedulingPeriod
-                {
-                    Id = periodId,
-                    OrganizationId = _orgId,
-                    Name = "Constraint Period",
-                    FromDate = DateTime.UtcNow,
-                    ToDate = DateTime.UtcNow.AddMonths(3),
-                    CreatedAt = DateTime.UtcNow,
-                    UpdatedAt = DateTime.UtcNow
-                });
-
-            db.Set<Subject>().Add(new Subject
-            {
-                Id = subjectId,
-                OrganizationId = _orgId,
-                DepartmentId = _deptId,
-                SchedulingPeriodId = periodId,
-                Code = "CS101",
-                Name = "Intro to CS",
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            });
-
-            db.Set<Activity>().Add(new Activity
-            {
-                Id = activityId,
-                OrganizationId = _orgId,
-                SubjectId = subjectId,
-                AssignedUserId = _userId,
-                ActivityType = "Lecture",
-                Duration = 2,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            });
-
-            await db.SaveChangesAsync();
-        }
-
-        return activityId;
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a resource owned by another organization must be invisible across the tenant boundary");
     }
 }

--- a/tests/Chronos.Tests.Acceptance/Flows/Health/SmokeTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Health/SmokeTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Chronos.Domain.Management.Roles;
 using Chronos.Tests.Acceptance.Infrastructure;
+using FluentAssertions;
 
 namespace Chronos.Tests.Acceptance.Flows.Health;
 
@@ -23,7 +24,7 @@ public class SmokeTests
 
         var response = await client.GetAsync("/api/department/00000000-0000-0000-0000-000000000000/resources/subjects/Subject");
 
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Test]
@@ -37,7 +38,7 @@ public class SmokeTests
 
         var response = await client.GetAsync("/api/department/00000000-0000-0000-0000-000000000000/resources/subjects/Subject");
 
-        Assert.That(response.StatusCode, Is.Not.EqualTo(HttpStatusCode.Unauthorized));
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
     }
 
     [Test]
@@ -46,8 +47,8 @@ public class SmokeTests
         var (scope, db) = _factory.GetDbContext();
         using (scope)
         {
-            Assert.That(db, Is.Not.Null);
-            Assert.That(db.Database.ProviderName, Does.Contain("InMemory"));
+            db.Should().NotBeNull();
+            db.Database.ProviderName.Should().Contain("InMemory");
         }
     }
 }

--- a/tests/Chronos.Tests.Acceptance/Flows/OrganizationManagement/OrganizationLifecycleTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/OrganizationManagement/OrganizationLifecycleTests.cs
@@ -1,175 +1,92 @@
 using System.Net;
-using Chronos.Domain.Management;
 using Chronos.Domain.Management.Roles;
 using Chronos.MainApi.Auth.Contracts;
 using Chronos.MainApi.Management.Contracts;
 using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
 using FluentAssertions;
 
 namespace Chronos.Tests.Acceptance.Flows.OrganizationManagement;
 
+/// <summary>
+/// Walks an organization through its lifecycle (info → soft-delete → restore) and
+/// verifies the surrounding admin surface (department CRUD, role assignment).
+/// Each test gets a fresh <see cref="AcceptanceContext"/> so mutations (soft-delete,
+/// department creation) don't leak between cases.
+/// </summary>
 [TestFixture]
 [Category("Acceptance")]
 public class OrganizationLifecycleTests
 {
-    private const string ValidInviteCode = "hih";
-
-    private ChronosApiFactory _factory = null!;
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp() => _factory = new ChronosApiFactory();
-
-    [OneTimeTearDown]
-    public void OneTimeTearDown() => _factory.Dispose();
-
     [Test]
     public async Task GivenRegisteredOrganization_WhenGetOrgInfo_ThenReturnsFullDetails()
     {
-        var client = _factory.CreateClient();
-        var regResponse = await client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest("org-info@chronos.dev", "Org", "Admin", "Passw0rd1"),
-                OrganizationName: "Info Test Org",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
+        using var ctx = await AcceptanceContext.CreateAsync("Info Test Org");
 
-        var auth = await regResponse.ReadJsonAsync<AuthResponse>();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", auth!.Token);
+        var info = await (await ctx.AdminClient.GetAsync("/api/management/organization/info"))
+            .ReadJsonAsync<OrganizationInformation>();
 
-        var infoResponse = await client.GetAsync("/api/management/organization/info");
-
-        infoResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var info = await infoResponse.ReadJsonAsync<OrganizationInformation>();
         info.Should().NotBeNull();
         info!.Name.Should().Be("Info Test Org");
-        info.UserEmail.Should().Be("org-info@chronos.dev");
+        info.UserEmail.Should().Be(ctx.AdminEmail);
         info.Deleted.Should().BeFalse();
     }
 
     [Test]
     public async Task GivenExistingOrganization_WhenSoftDeleteAndRestore_ThenLifecycleCompletes()
     {
-        var client = _factory.CreateClient();
-        var regResponse = await client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest("lifecycle@chronos.dev", "Life", "Cycle", "Passw0rd1"),
-                OrganizationName: "Lifecycle Org",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
+        using var ctx = await AcceptanceContext.CreateAsync();
 
-        var auth = await regResponse.ReadJsonAsync<AuthResponse>();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", auth!.Token);
-
-        var orgInfo = await (await client.GetAsync("/api/management/organization/info"))
-            .ReadJsonAsync<OrganizationInformation>();
-        client.DefaultRequestHeaders.Add("x-org-id", orgInfo!.Id.ToString());
-
-        // Soft-delete the organization
-        var deleteResponse = await client.DeleteAsync("/api/management/organization");
+        var deleteResponse = await ctx.AdminClient.DeleteAsync("/api/management/organization");
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        // Restore the organization
-        var restoreResponse = await client.PostAsync("/api/management/organization/restore", null);
+        var restoreResponse = await ctx.AdminClient.PostAsync("/api/management/organization/restore", null);
         restoreResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        // Verify it's restored by fetching info again
-        var infoAfterRestore = await (await client.GetAsync("/api/management/organization/info"))
+        var infoAfterRestore = await (await ctx.AdminClient.GetAsync("/api/management/organization/info"))
             .ReadJsonAsync<OrganizationInformation>();
         infoAfterRestore!.Deleted.Should().BeFalse();
     }
 
     [Test]
-    public async Task GivenExistingOrganization_WhenCreateDepartment_ThenReturns201()
+    public async Task GivenExistingOrganization_WhenCreateDepartment_ThenCreatesDepartment()
     {
-        var client = _factory.CreateClient();
-        var regResponse = await client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest("dept-create@chronos.dev", "Dept", "Creator", "Passw0rd1"),
-                OrganizationName: "Dept Create Org",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
+        using var ctx = await AcceptanceContext.CreateAsync();
 
-        var auth = await regResponse.ReadJsonAsync<AuthResponse>();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", auth!.Token);
+        var dept = await ctx.Seed.CreateDepartmentAsync("Computer Science");
 
-        var orgInfo = await (await client.GetAsync("/api/management/organization/info"))
-            .ReadJsonAsync<OrganizationInformation>();
-        client.DefaultRequestHeaders.Add("x-org-id", orgInfo!.Id.ToString());
-
-        var createResponse = await client.PostJsonAsync("/api/management/department",
-            new DepartmentRequest("Computer Science"));
-
-        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var dept = await createResponse.ReadJsonAsync<DepartmentResponse>();
-        dept!.Name.Should().Be("Computer Science");
+        dept.Name.Should().Be("Computer Science");
         dept.Deleted.Should().BeFalse();
     }
 
     [Test]
     public async Task GivenExistingDepartment_WhenGetDepartments_ThenIncludesCreatedDepartment()
     {
-        var client = _factory.CreateClient();
-        var regResponse = await client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest("dept-list@chronos.dev", "Dept", "Lister", "Passw0rd1"),
-                OrganizationName: "Dept List Org",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
+        using var ctx = await AcceptanceContext.CreateAsync();
 
-        var auth = await regResponse.ReadJsonAsync<AuthResponse>();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", auth!.Token);
+        await ctx.Seed.CreateDepartmentAsync("Mathematics");
+        await ctx.Seed.CreateDepartmentAsync("Physics");
 
-        var orgInfo = await (await client.GetAsync("/api/management/organization/info"))
-            .ReadJsonAsync<OrganizationInformation>();
-        client.DefaultRequestHeaders.Add("x-org-id", orgInfo!.Id.ToString());
+        var departments = await (await ctx.AdminClient.GetAsync("/api/management/department"))
+            .ReadJsonAsync<DepartmentResponse[]>();
 
-        await client.PostJsonAsync("/api/management/department", new DepartmentRequest("Mathematics"));
-        await client.PostJsonAsync("/api/management/department", new DepartmentRequest("Physics"));
-
-        var listResponse = await client.GetAsync("/api/management/department");
-
-        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var departments = await listResponse.ReadJsonAsync<DepartmentResponse[]>();
         departments.Should().NotBeNull();
-        departments!.Length.Should().BeGreaterThanOrEqualTo(2);
-        departments.Select(d => d.Name).Should().Contain("Mathematics").And.Contain("Physics");
+        departments!.Select(d => d.Name).Should().Contain(["Mathematics", "Physics"]);
     }
 
     [Test]
     public async Task GivenRegisteredOrganization_WhenCreateAndAssignRole_ThenRoleIsRetrievable()
     {
-        var client = _factory.CreateClient();
-        var regResponse = await client.PostJsonAsync("/api/auth/register",
-            new RegisterRequest(
-                AdminUser: new CreateUserRequest("role-test@chronos.dev", "Role", "Tester", "Passw0rd1"),
-                OrganizationName: "Role Test Org",
-                Plan: "free",
-                InviteCode: ValidInviteCode));
+        using var ctx = await AcceptanceContext.CreateAsync();
 
-        var auth = await regResponse.ReadJsonAsync<AuthResponse>();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", auth!.Token);
+        var createdUser = await ctx.Seed.CreateUserAsync("role-target@chronos.dev");
 
-        var orgInfo = await (await client.GetAsync("/api/management/organization/info"))
-            .ReadJsonAsync<OrganizationInformation>();
-        client.DefaultRequestHeaders.Add("x-org-id", orgInfo!.Id.ToString());
-
-        // Create a second user to assign a role to
-        var createUserResponse = await client.PostJsonAsync("/api/user",
-            new CreateUserRequest("role-target@chronos.dev", "Target", "User", "Passw0rd2"));
-        createUserResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var createdUser = await createUserResponse.ReadJsonAsync<CreateUserResponse>();
-
-        var roleResponse = await client.PostJsonAsync("/api/management/role",
-            new RoleAssignmentRequest(null, Guid.Parse(createdUser!.UserId), RoleType.Viewer));
+        var roleResponse = await ctx.AdminClient.PostJsonAsync("/api/management/role",
+            new RoleAssignmentRequest(null, Guid.Parse(createdUser.UserId), RoleType.Viewer));
 
         roleResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var rolesResponse = await client.GetAsync(
+        var rolesResponse = await ctx.AdminClient.GetAsync(
             $"/api/management/role/user/{createdUser.UserId}");
         rolesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/tests/Chronos.Tests.Acceptance/Infrastructure/ChronosApiFactory.cs
+++ b/tests/Chronos.Tests.Acceptance/Infrastructure/ChronosApiFactory.cs
@@ -120,9 +120,8 @@ public class ChronosApiFactory : WebApplicationFactory<AuthConfiguration>
             TestSecretKey, TestIssuer, TestAudience);
 
         var client = CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new global::System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-        client.DefaultRequestHeaders.Add("x-org-id", organizationId.ToString());
+        client.UseBearerToken(token);
+        client.SetOrgHeader(organizationId);
 
         return client;
     }

--- a/tests/Chronos.Tests.Acceptance/Infrastructure/HttpClientExtensions.cs
+++ b/tests/Chronos.Tests.Acceptance/Infrastructure/HttpClientExtensions.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -21,6 +22,11 @@ public static class HttpClientExtensions
     {
         client.DefaultRequestHeaders.Remove("x-org-id");
         client.DefaultRequestHeaders.Add("x-org-id", organizationId.ToString());
+    }
+
+    public static void UseBearerToken(this HttpClient client, string token)
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
     }
 
     public static async Task<HttpResponseMessage> PostJsonAsync<T>(

--- a/tests/Chronos.Tests.Acceptance/Support/AcceptanceContext.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/AcceptanceContext.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using Chronos.Domain.Management.Roles;
 using Chronos.MainApi.Auth.Contracts;
 using Chronos.MainApi.Management.Contracts;
@@ -20,6 +19,8 @@ public sealed class AcceptanceContext : IDisposable
     public Guid AdminUserId { get; }
     public string AdminEmail { get; }
 
+    private readonly bool _ownsFactory;
+
     /// <summary>Seeds domain data through the API as the organization administrator.</summary>
     public Seeder Seed { get; }
 
@@ -28,13 +29,15 @@ public sealed class AcceptanceContext : IDisposable
         HttpClient adminClient,
         Guid organizationId,
         Guid adminUserId,
-        string adminEmail)
+        string adminEmail,
+        bool ownsFactory)
     {
         Factory = factory;
         AdminClient = adminClient;
         OrganizationId = organizationId;
         AdminUserId = adminUserId;
         AdminEmail = adminEmail;
+        _ownsFactory = ownsFactory;
         Seed = new Seeder(adminClient);
     }
 
@@ -42,9 +45,28 @@ public sealed class AcceptanceContext : IDisposable
     /// Boots the API, registers a new organization + administrator, and returns a
     /// context whose <see cref="AdminClient"/> is authenticated and scoped to it.
     /// </summary>
-    public static async Task<AcceptanceContext> CreateAsync(string? organizationName = null)
+    public static Task<AcceptanceContext> CreateAsync(string? organizationName = null)
     {
-        var factory = new ChronosApiFactory();
+        return CreateAsync(new ChronosApiFactory(), ownsFactory: true, organizationName);
+    }
+
+    /// <summary>
+    /// Registers another organization inside an existing API factory/database. Use
+    /// this for tenant-isolation scenarios where both organizations must coexist in
+    /// the same test host.
+    /// </summary>
+    public static Task<AcceptanceContext> CreateAsync(
+        ChronosApiFactory factory,
+        string? organizationName = null)
+    {
+        return CreateAsync(factory, ownsFactory: false, organizationName);
+    }
+
+    private static async Task<AcceptanceContext> CreateAsync(
+        ChronosApiFactory factory,
+        bool ownsFactory,
+        string? organizationName)
+    {
         var client = factory.CreateClient();
 
         var email = $"admin-{Guid.NewGuid():N}@chronos.test";
@@ -57,7 +79,7 @@ public sealed class AcceptanceContext : IDisposable
 
         var auth = await register.ReadJsonAsync<AuthResponse>()
                    ?? throw new InvalidOperationException("Registration returned no auth token.");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth.Token);
+        client.UseBearerToken(auth.Token);
 
         var info = await (await client.GetAsync("/api/management/organization/info"))
                        .ReadJsonAsync<OrganizationInformation>()
@@ -66,7 +88,7 @@ public sealed class AcceptanceContext : IDisposable
 
         var adminUserId = info.UserRoles.FirstOrDefault()?.UserId ?? Guid.Empty;
 
-        return new AcceptanceContext(factory, client, info.Id, adminUserId, email);
+        return new AcceptanceContext(factory, client, info.Id, adminUserId, email, ownsFactory);
     }
 
     /// <summary>
@@ -87,6 +109,7 @@ public sealed class AcceptanceContext : IDisposable
     public void Dispose()
     {
         AdminClient.Dispose();
-        Factory.Dispose();
+        if (_ownsFactory)
+            Factory.Dispose();
     }
 }

--- a/tests/Chronos.Tests.Acceptance/Support/Seeder.Scheduling.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/Seeder.Scheduling.cs
@@ -70,6 +70,32 @@ public sealed partial class Seeder
                ?? throw new InvalidOperationException("Create activity returned no body.");
     }
 
+    public async Task<ActivityResponse> CreateActivityWithPrerequisitesAsync(Guid organizationId)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var dept = await CreateDepartmentAsync($"Activity Dept {suffix}");
+        var period = await CreateSchedulingPeriodAsync(
+            $"Activity Period {suffix}",
+            new DateTime(2026, 9, 1),
+            new DateTime(2027, 1, 31));
+        var instructor = await CreateUserAsync($"activity-instructor-{suffix}@chronos.test");
+        var subject = await CreateSubjectAsync(
+            organizationId,
+            dept.Id,
+            Guid.Parse(period.Id),
+            $"ACT{suffix}",
+            $"Activity Subject {suffix}");
+
+        return await CreateActivityAsync(
+            organizationId,
+            dept.Id,
+            subject.Id,
+            Guid.Parse(instructor.UserId),
+            "Lecture",
+            expectedStudents: 25,
+            duration: 2);
+    }
+
     public async Task<AssignmentResponse> CreateAssignmentAsync(Guid slotId, Guid resourceId, Guid activityId, int weekNum)
     {
         var response = await client.PostJsonAsync("/api/schedule/scheduling/assignments",


### PR DESCRIPTION
## Description

Improves the existing acceptance tests by aligning older flows with the newer `AcceptanceContext` / `Seeder` test support style and removing duplicated setup boilerplate.

## Changes Made

- Refactored older acceptance tests to use shared helpers where appropriate:
  - `OrganizationLifecycleTests`
  - `RbacEnforcementTests`
  - `AuthFlowTests`
  - `ErrorHandlingTests`
  - `SmokeTests`
- Added `HttpClientExtensions.UseBearerToken(...)` and reused existing `SetOrgHeader(...)`.
- Updated `ChronosApiFactory.CreateAuthenticatedClient(...)` to use the shared HTTP client helpers.
- Extended `AcceptanceContext` so tests can create an additional organization inside the same `ChronosApiFactory` / in-memory database.
- Fixed the RBAC cross-organization test so it now verifies tenant isolation against two organizations in the same test host/database.
- Removed direct `DbContext` seeding from `RbacEnforcementTests` and replaced it with API-driven seeding through `Seeder`.
- Added `Seeder.CreateActivityWithPrerequisitesAsync(...)` for reusable activity setup.

## Testing

- Ran acceptance tests:

```bash
dotnet test tests/Chronos.Tests.Acceptance/Chronos.Tests.Acceptance.csproj --filter Category=Acceptance --nologo