### PR TITLE
Feature/shalevkk/123/appeals lifecycle acceptance tests

### DIFF
--- a/tests/Chronos.Tests.Acceptance/Flows/Appeals/AppealLifecycleTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Appeals/AppealLifecycleTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using Chronos.MainApi.Schedule.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
+using FluentAssertions;
+
+namespace Chronos.Tests.Acceptance.Flows.Appeals;
+
+[TestFixture]
+[Category("Acceptance")]
+public class AppealLifecycleTests
+{
+    private AcceptanceContext _ctx = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _ctx = await AcceptanceContext.CreateAsync("Appeals Acceptance Org");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _ctx.Dispose();
+    }
+
+    [Test]
+    public async Task GivenAssignment_WhenAppealIsSubmitted_ThenItIsVisibleForTheAssignmentAndAssignedUser()
+    {
+        var setup = await CreateAssignedActivityAsync();
+
+        var create = await _ctx.AdminClient.PostJsonAsync("/api/schedule/scheduling/appeals",
+            new CreateAppealRequest(setup.AssignmentId, "Room conflict", "The assigned room is too small."));
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var created = await create.ReadJsonAsync<AppealResponse>();
+        created.Should().NotBeNull();
+        created!.AssignmentId.Should().Be(setup.AssignmentId.ToString());
+        created.OrganizationId.Should().Be(_ctx.OrganizationId.ToString());
+        created.Title.Should().Be("Room conflict");
+        created.Description.Should().Be("The assigned room is too small.");
+        created.CreatedAt.Should().NotBe(default);
+        created.UpdatedAt.Should().NotBe(default);
+
+        var appealId = Guid.Parse(created.Id);
+
+        var byId = await ReadAppealAsync($"/api/schedule/scheduling/appeals/{appealId}");
+        byId.Should().BeEquivalentTo(created);
+
+        var allAppeals = await ReadAppealsAsync("/api/schedule/scheduling/appeals");
+        allAppeals.Should().ContainSingle(a => a.Id == created.Id);
+
+        var byAssignment = await ReadAppealsAsync($"/api/schedule/scheduling/assignments/{setup.AssignmentId}/appeals");
+        byAssignment.Should().ContainSingle(a => a.Id == created.Id);
+
+        var byUser = await ReadAppealsAsync($"/api/schedule/scheduling/users/{setup.AssignedUserId}/appeals");
+        byUser.Should().ContainSingle(a => a.Id == created.Id);
+    }
+
+    [Test]
+    public async Task GivenAssignmentWithExistingAppeal_WhenAnotherAppealIsSubmitted_ThenDuplicateIsRejectedAndOriginalRemains()
+    {
+        var setup = await CreateAssignedActivityAsync();
+
+        var first = await _ctx.AdminClient.PostJsonAsync("/api/schedule/scheduling/appeals",
+            new CreateAppealRequest(setup.AssignmentId, "Initial appeal", "First explanation."));
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+        var original = await first.ReadJsonAsync<AppealResponse>();
+        original.Should().NotBeNull();
+
+        var duplicate = await _ctx.AdminClient.PostJsonAsync("/api/schedule/scheduling/appeals",
+            new CreateAppealRequest(setup.AssignmentId, "Duplicate appeal", "Second explanation."));
+
+        duplicate.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var byAssignment = await ReadAppealsAsync($"/api/schedule/scheduling/assignments/{setup.AssignmentId}/appeals");
+        byAssignment.Should().ContainSingle();
+        byAssignment[0].Id.Should().Be(original!.Id);
+        byAssignment[0].Title.Should().Be("Initial appeal");
+        byAssignment[0].Description.Should().Be("First explanation.");
+    }
+
+    [Test]
+    public async Task GivenMissingAssignment_WhenAppealIsSubmitted_ThenRequestIsRejected()
+    {
+        var missingAssignmentId = Guid.NewGuid();
+
+        var response = await _ctx.AdminClient.PostJsonAsync("/api/schedule/scheduling/appeals",
+            new CreateAppealRequest(missingAssignmentId, "Cannot attend", "The referenced assignment does not exist."));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task<AssignedActivity> CreateAssignedActivityAsync()
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var department = await _ctx.Seed.CreateDepartmentAsync($"Appeals Dept {suffix}");
+        var period = await _ctx.Seed.CreateSchedulingPeriodAsync(
+            $"Appeals Period {suffix}",
+            DateTime.UtcNow.Date.AddDays(30),
+            DateTime.UtcNow.Date.AddDays(120));
+        var slot = await _ctx.Seed.CreateSlotAsync(
+            Guid.Parse(period.Id),
+            WeekDays.Monday,
+            TimeSpan.FromHours(9),
+            TimeSpan.FromHours(11));
+        var resourceType = await _ctx.Seed.CreateResourceTypeAsync(_ctx.OrganizationId, $"Appeals Room {suffix}");
+        var resource = await _ctx.Seed.CreateResourceAsync(
+            _ctx.OrganizationId,
+            resourceType.Id,
+            "Appeals Building",
+            $"Room {suffix}",
+            capacity: 80);
+        var user = await _ctx.Seed.CreateUserAsync($"appeals-instructor-{suffix}@chronos.test");
+        var subject = await _ctx.Seed.CreateSubjectAsync(
+            _ctx.OrganizationId,
+            department.Id,
+            Guid.Parse(period.Id),
+            $"APL{suffix}",
+            $"Appeals Subject {suffix}");
+        var activity = await _ctx.Seed.CreateActivityAsync(
+            _ctx.OrganizationId,
+            department.Id,
+            subject.Id,
+            Guid.Parse(user.UserId),
+            "Lecture",
+            expectedStudents: 35,
+            duration: 2);
+        var assignment = await _ctx.Seed.CreateAssignmentAsync(
+            Guid.Parse(slot.Id),
+            resource.Id,
+            activity.Id,
+            weekNum: 1);
+
+        return new AssignedActivity(
+            Guid.Parse(assignment.Id),
+            Guid.Parse(user.UserId));
+    }
+
+    private async Task<AppealResponse> ReadAppealAsync(string url)
+    {
+        var response = await _ctx.AdminClient.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<AppealResponse>()
+               ?? throw new InvalidOperationException($"GET {url} returned no appeal.");
+    }
+
+    private async Task<AppealResponse[]> ReadAppealsAsync(string url)
+    {
+        var response = await _ctx.AdminClient.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<AppealResponse[]>()
+               ?? throw new InvalidOperationException($"GET {url} returned no appeals.");
+    }
+
+    private sealed record AssignedActivity(Guid AssignmentId, Guid AssignedUserId);
+}

--- a/tests/Chronos.Tests.Acceptance/Flows/Constraints/ConstraintsAndPreferencesTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Constraints/ConstraintsAndPreferencesTests.cs
@@ -61,7 +61,7 @@ public class ConstraintsAndPreferencesTests
         afterCreate!.Value.Should().Be("Friday");
 
         var update = await _ctx.AdminClient.PatchJsonAsync($"{ConstraintsBase}/userConstraint/{created.Id}",
-            new UpdateUserConstraintRequest("unavailable_day", "Monday"));
+            new UpdateUserConstraintRequest(_userId, _periodId, "unavailable_day", "Monday"));
         update.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         var afterUpdate = await (await _ctx.AdminClient.GetAsync($"{ConstraintsBase}/userConstraint/{created.Id}"))


### PR DESCRIPTION
## Description

Adds meaningful acceptance coverage for the Appeals feature. The tests focus on
user/business requirements rather than CRUD coverage: an appeal can be submitted for
a real scheduled assignment, it appears in the relevant appeal views, duplicate appeals
for the same assignment are rejected, and appeals cannot be submitted for missing
assignments.

## Related Issues

Closes bgu-nasa/main#123

## Changes Made

- Added `Flows/Appeals/AppealLifecycleTests.cs`
- Seeds a real schedulable assignment through the public API before submitting appeals:
  department → period → slot → resource type → resource → user → subject → activity → assignment
- Added acceptance coverage for:
  - submitting an appeal for an assignment
  - reading the appeal by id
  - seeing the appeal in the all-appeals view
  - seeing the appeal in the assignment-specific appeals view
  - seeing the appeal in the assigned-user appeals view
  - rejecting a duplicate appeal for the same assignment
  - rejecting an appeal for a missing assignment
- Updated the existing constraints acceptance test to use the current
  `UpdateUserConstraintRequest` signature (`UserId`, `SchedulingPeriodId`, `Key`, `Value`)

## Testing

-   [x] Acceptance tests added/updated
-   [x] All existing tests pass

### Test Instructions

`dotnet test tests/Chronos.Tests.Acceptance/Chronos.Tests.Acceptance.csproj --nologo -v q`

Result: 43 passed, 0 failed.

## Checklist

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [x] My changes generate no new errors
-   [x] I have added tests that prove the feature works
-   [x] New and existing tests pass locally with my changes

## Database Changes

-   [x] No database changes

## Configuration Changes

-   [x] No configuration changes required