### PR TITLE
Created user roles acceptance tests

### DIFF
--- a/tests/Chronos.Tests.Acceptance/Flows/UserRoleAdmin/UserRoleAdministrationTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/UserRoleAdmin/UserRoleAdministrationTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using Chronos.MainApi.Auth.Contracts;
+using Chronos.MainApi.Management.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
+using FluentAssertions;
+
+namespace Chronos.Tests.Acceptance.Flows.UserRoleAdmin;
+
+[TestFixture]
+[Category("Acceptance")]
+public class UserRoleAdministrationTests
+{
+    private AcceptanceContext _ctx = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _ctx = await AcceptanceContext.CreateAsync("User Role Admin Acceptance Org");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _ctx.Dispose();
+    }
+
+    [Test]
+    public async Task GivenNewUser_WhenAdminGrantsAndRevokesDepartmentRole_ThenRoleViewsReflectCurrentAccess()
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var user = await _ctx.Seed.CreateUserAsync(
+            $"role-target-{suffix}@chronos.test",
+            firstName: "Role",
+            lastName: "Target");
+        var userId = Guid.Parse(user.UserId);
+        var department = await _ctx.Seed.CreateDepartmentAsync($"Access Dept {suffix}");
+
+        var userProfile = await ReadUserAsync(userId);
+        userProfile.Email.Should().Be(user.Email);
+        userProfile.FirstName.Should().Be("Role");
+        userProfile.LastName.Should().Be("Target");
+
+        var updateProfile = await _ctx.AdminClient.PutJsonAsync($"/api/user/{userId}",
+            new UserUpdateRequest("Updated", "Target", "https://example.com/avatar.png"));
+        updateProfile.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var updatedProfile = await ReadUserAsync(userId);
+        updatedProfile.FirstName.Should().Be("Updated");
+        updatedProfile.AvatarUrl.Should().Be("https://example.com/avatar.png");
+
+        var assignRole = await _ctx.AdminClient.PostJsonAsync("/api/management/role",
+            new RoleAssignmentRequest(department.Id, userId, RoleType.ResourceManager));
+        assignRole.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var roleAssignment = await assignRole.ReadJsonAsync<RoleAssignmentResponse>();
+        roleAssignment.Should().NotBeNull();
+        roleAssignment!.UserId.Should().Be(userId);
+        roleAssignment.OrganizationId.Should().Be(_ctx.OrganizationId);
+        roleAssignment.DepartmentId.Should().Be(department.Id);
+        roleAssignment.Role.Should().Be(RoleType.ResourceManager);
+
+        var byId = await ReadRoleAssignmentAsync(roleAssignment.Id);
+        byId.Should().BeEquivalentTo(roleAssignment);
+
+        var rolesForUser = await ReadRoleAssignmentsAsync($"/api/management/role/user/{userId}");
+        rolesForUser.Should().ContainSingle(r => r.Id == roleAssignment.Id);
+
+        var allRoles = await ReadRoleAssignmentsAsync("/api/management/role");
+        allRoles.Should().Contain(r => r.Id == roleAssignment.Id);
+
+        var summary = await ReadRoleSummaryAsync();
+        summary.Should().ContainSingle(s =>
+            s.UserEmail == user.Email &&
+            s.Assignments.Any(a => a.Id == roleAssignment.Id));
+
+        var revoke = await _ctx.AdminClient.DeleteAsync($"/api/management/role/{roleAssignment.Id}");
+        revoke.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var rolesAfterRevoke = await ReadRoleAssignmentsAsync($"/api/management/role/user/{userId}");
+        rolesAfterRevoke.Should().NotContain(r => r.Id == roleAssignment.Id);
+
+        var deleteUser = await _ctx.AdminClient.DeleteAsync($"/api/user/{userId}");
+        deleteUser.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var afterDelete = await _ctx.AdminClient.GetAsync($"/api/user/{userId}");
+        afterDelete.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task GivenMissingDepartment_WhenAdminAssignsDepartmentRole_ThenRequestIsRejected()
+    {
+        var user = await _ctx.Seed.CreateUserAsync($"missing-dept-target-{Guid.NewGuid():N}@chronos.test");
+
+        var response = await _ctx.AdminClient.PostJsonAsync("/api/management/role",
+            new RoleAssignmentRequest(Guid.NewGuid(), Guid.Parse(user.UserId), RoleType.Operator));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task GivenSystemAssignedAdminRole_WhenAdminTriesToRevokeIt_ThenRequestIsRejected()
+    {
+        var adminRoles = await ReadRoleAssignmentsAsync($"/api/management/role/user/{_ctx.AdminUserId}");
+        var adminRole = adminRoles.Single(r => r.Role == RoleType.Administrator && r.DepartmentId is null);
+
+        var response = await _ctx.AdminClient.DeleteAsync($"/api/management/role/{adminRole.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var rolesAfterAttempt = await ReadRoleAssignmentsAsync($"/api/management/role/user/{_ctx.AdminUserId}");
+        rolesAfterAttempt.Should().ContainSingle(r => r.Id == adminRole.Id);
+    }
+
+    private async Task<UserResponse> ReadUserAsync(Guid userId)
+    {
+        var response = await _ctx.AdminClient.GetAsync($"/api/user/{userId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<UserResponse>()
+               ?? throw new InvalidOperationException($"GET /api/user/{userId} returned no user.");
+    }
+
+    private async Task<RoleAssignmentResponse> ReadRoleAssignmentAsync(Guid roleAssignmentId)
+    {
+        var response = await _ctx.AdminClient.GetAsync($"/api/management/role/{roleAssignmentId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<RoleAssignmentResponse>()
+               ?? throw new InvalidOperationException($"GET /api/management/role/{roleAssignmentId} returned no role.");
+    }
+
+    private async Task<RoleAssignmentResponse[]> ReadRoleAssignmentsAsync(string url)
+    {
+        var response = await _ctx.AdminClient.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<RoleAssignmentResponse[]>()
+               ?? throw new InvalidOperationException($"GET {url} returned no roles.");
+    }
+
+    private async Task<UserRoleAssignmentSummary[]> ReadRoleSummaryAsync()
+    {
+        var response = await _ctx.AdminClient.GetAsync("/api/management/role/summary");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<UserRoleAssignmentSummary[]>()
+               ?? throw new InvalidOperationException("GET /api/management/role/summary returned no summary.");
+    }
+}

--- a/tests/Chronos.Tests.Acceptance/Infrastructure/HttpClientExtensions.cs
+++ b/tests/Chronos.Tests.Acceptance/Infrastructure/HttpClientExtensions.cs
@@ -43,6 +43,12 @@ public static class HttpClientExtensions
         return await client.PatchAsync(url, content);
     }
 
+    public static async Task<HttpResponseMessage> PutJsonAsync<T>(
+        this HttpClient client, string url, T payload)
+    {
+        return await client.PutAsJsonAsync(url, payload, JsonOptions);
+    }
+
     public static async Task<TResponse?> ReadJsonAsync<TResponse>(
         this HttpResponseMessage response)
     {


### PR DESCRIPTION
## Description

Adds meaningful acceptance coverage for user and role administration. The tests focus
on the access-management workflow rather than endpoint-by-endpoint CRUD: an admin can
create a user, update their profile, grant department-scoped access, verify the role is
visible in the relevant management views, revoke that access, and delete the user.
The PR also covers two important failure rules around invalid role assignment and
system-assigned admin role protection.

## Related Issues

Closes bgu-nasa/main#124

## Changes Made

- Added `Flows/UserRoleAdmin/UserRoleAdministrationTests.cs`
- Added acceptance coverage for:
  - creating a user through the public API
  - reading and updating the user's profile
  - assigning a department-scoped role
  - verifying the assignment by id, by user, in all assignments, and in the role summary
  - revoking the role assignment
  - deleting the user and confirming it is no longer readable
  - rejecting a role assignment for a missing department
  - rejecting removal of the system-assigned administrator role
- Added `PutJsonAsync` to `HttpClientExtensions` so acceptance tests use the same JSON options
  for PUT requests as POST/PATCH requests.

## Testing

-   [x] Acceptance tests added/updated
-   [x] All existing tests pass

### Test Instructions

`dotnet test tests/Chronos.Tests.Acceptance/Chronos.Tests.Acceptance.csproj --nologo -v q`

Result: 46 passed, 0 failed.

## Checklist

-   [x] My code follows the project's code style guidelines
-   [x] I have performed a self-review of my own code
-   [x] My changes generate no new errors
-   [x] I have added tests that prove the feature works
-   [x] New and existing tests pass locally with my changes

## Database Changes

-   [x] No database changes

## Configuration Changes

-   [x] No configuration changes required

## Additional Context

- This PR intentionally does not add negative RBAC tests (for example, Viewer cannot manage
  users/roles). Authorization acceptance coverage is deferred until the known RBAC hierarchy
  issue is fixed.
- The tests intentionally avoid exhaustive CRUD permutations. The goal is to cover the
  real user/role administration workflow and meaningful failure rules.
- Role assignment to a non-existent user is not tested here because the current service does
  not validate target user existence. That should be handled as a separate product/bug decision
  if desired.
- Existing warnings remain, including the known warning from the commented-out user preference
  test in `ConstraintsAndPreferencesTests.cs`, which is reserved for the final cleanup/fixes PR.