### PR TITLE
Acceptance tests for agent and md file for acceptance tests

### DIFF
--- a/tests/Chronos.Tests.Acceptance/Flows/Agent/AgentSubmissionTests.cs
+++ b/tests/Chronos.Tests.Acceptance/Flows/Agent/AgentSubmissionTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using Chronos.Agent.Conversation;
+using Chronos.MainApi.Agent.Contracts;
+using Chronos.MainApi.Schedule.Contracts;
+using Chronos.Tests.Acceptance.Infrastructure;
+using Chronos.Tests.Acceptance.Support;
+using FluentAssertions;
+
+namespace Chronos.Tests.Acceptance.Flows.Agent;
+
+[TestFixture]
+[Category("Acceptance")]
+public class AgentSubmissionTests
+{
+    private const string AgentBase = "/api/agent";
+    private const string ConstraintsBase = "/api/schedule/constraints";
+
+    [Test]
+    public async Task GivenSchedulingPreferences_WhenAgentDraftIsApproved_ThenConstraintsAndPreferencesArePersisted()
+    {
+        using var ctx = await AcceptanceContext.CreateAsync("Agent Acceptance Org");
+        var from = DateTime.UtcNow.Date.AddDays(30);
+        var period = await ctx.Seed.CreateSchedulingPeriodAsync("Agent Term", from, from.AddMonths(4));
+        var periodId = Guid.Parse(period.Id);
+
+        var start = await ctx.AdminClient.PostJsonAsync(
+            $"{AgentBase}/sessions",
+            new StartSessionRequest(periodId, "Asia/Jerusalem"));
+
+        start.StatusCode.Should().Be(HttpStatusCode.Created);
+        var session = await start.ReadJsonAsync<CreatedAgentSession>()
+                      ?? throw new InvalidOperationException("Agent session creation returned no session id.");
+
+        var message = await ctx.AdminClient.PostJsonAsync(
+            $"{AgentBase}/sessions/{session.SessionId}/messages",
+            new SendMessageRequest("I cannot teach Fridays and prefer Mondays."));
+
+        message.StatusCode.Should().Be(HttpStatusCode.OK);
+        var conversation = await message.ReadJsonAsync<AgentSessionEnvelope>();
+        conversation.Should().NotBeNull();
+        conversation!.State.Should().Be(AgentState.Discovery);
+        conversation.AssistantMessage.Should().NotBeNullOrWhiteSpace();
+
+        var submit = await ctx.AdminClient.PostJsonAsync(
+            $"{AgentBase}/sessions/{session.SessionId}/submit",
+            new { });
+
+        submit.StatusCode.Should().Be(HttpStatusCode.OK);
+        var draft = await submit.ReadJsonAsync<AgentSessionEnvelope>();
+        draft.Should().NotBeNull();
+        draft!.State.Should().Be(AgentState.Submit);
+        draft.AllowedActions.Should().BeEquivalentTo(new[] { AgentAction.Approve, AgentAction.Revise });
+        draft.ValidationIssues.Should().BeEmpty();
+        draft.Draft.Should().NotBeNull();
+        draft.Draft!.HardConstraints.Should().ContainSingle(c =>
+            c.Key == "forbidden_timerange" && c.Value == "Friday 09:00 - 17:00");
+        draft.Draft.SoftPreferences.Should().ContainSingle(p =>
+            p.Key == "preferred_weekday" && p.Value == "Monday");
+
+        var approve = await ctx.AdminClient.PostJsonAsync(
+            $"{AgentBase}/sessions/{session.SessionId}/approve",
+            new { });
+
+        approve.StatusCode.Should().Be(HttpStatusCode.OK);
+        var approved = await approve.ReadJsonAsync<AgentSessionEnvelope>();
+        approved.Should().NotBeNull();
+        approved!.State.Should().Be(AgentState.Approved);
+        approved.AllowedActions.Should().BeEmpty();
+
+        var persistedConstraints = await ReadArrayAsync<UserConstraintResponse>(
+            ctx.AdminClient,
+            $"{ConstraintsBase}/userConstraint/by-period-and-user/{periodId}/{ctx.AdminUserId}");
+        persistedConstraints.Should().ContainSingle(c =>
+            c.Key == "forbidden_timerange"
+            && c.Value == "Friday 09:00 - 17:00"
+            && c.UserId == ctx.AdminUserId.ToString()
+            && c.SchedulingPeriodId == periodId.ToString());
+
+        var persistedPreferences = await ReadArrayAsync<UserPreferenceResponse>(
+            ctx.AdminClient,
+            $"{ConstraintsBase}/preferenceConstraint/by-period-and-user/{periodId}/{ctx.AdminUserId}");
+        persistedPreferences.Should().ContainSingle(p =>
+            p.Key == "preferred_weekday"
+            && p.Value == "Monday"
+            && p.UserId == ctx.AdminUserId.ToString()
+            && p.SchedulingPeriodId == periodId.ToString());
+    }
+
+    private static async Task<T[]> ReadArrayAsync<T>(HttpClient client, string url)
+    {
+        var response = await client.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await response.ReadJsonAsync<T[]>()
+               ?? throw new InvalidOperationException($"GET {url} returned no response body.");
+    }
+
+    private sealed record CreatedAgentSession(Guid SessionId);
+    private sealed record AgentSessionEnvelope(
+        Guid SessionId,
+        AgentState State,
+        string? AssistantMessage,
+        DraftEnvelope? Draft,
+        List<AgentAction> AllowedActions,
+        List<ValidationIssueEnvelope> ValidationIssues);
+
+    private sealed record DraftEnvelope(
+        List<DraftItemEnvelope> HardConstraints,
+        List<DraftItemEnvelope> SoftPreferences);
+
+    private sealed record DraftItemEnvelope(string Key, string Value);
+    private sealed record ValidationIssueEnvelope(string Kind, string Key, string Value, string Reason);
+}

--- a/tests/Chronos.Tests.Acceptance/Infrastructure/ChronosApiFactory.cs
+++ b/tests/Chronos.Tests.Acceptance/Infrastructure/ChronosApiFactory.cs
@@ -1,3 +1,5 @@
+using Chronos.Agent.Conversation;
+using Chronos.Agent.Extraction;
 using Chronos.Data.Context;
 using Chronos.MainApi.Auth.Configuration;
 using Chronos.MainApi.Schedule.Messaging;
@@ -12,7 +14,7 @@ namespace Chronos.Tests.Acceptance.Infrastructure;
 
 /// <summary>
 /// Custom WebApplicationFactory that replaces external dependencies
-/// (PostgreSQL, RabbitMQ) with in-memory/mock equivalents.
+/// (PostgreSQL, RabbitMQ, LLM provider) with deterministic test equivalents.
 /// </summary>
 public class ChronosApiFactory : WebApplicationFactory<AuthConfiguration>
 {
@@ -45,6 +47,7 @@ public class ChronosApiFactory : WebApplicationFactory<AuthConfiguration>
         {
             ReplaceDatabase(services);
             ReplaceMessagePublisher(services);
+            ReplaceAgentLlmAdapter(services);
             ConfigureTestAuth(services);
         });
     }
@@ -95,6 +98,17 @@ public class ChronosApiFactory : WebApplicationFactory<AuthConfiguration>
         services.AddSingleton(Substitute.For<IRabbitMqConnectionFactory>());
     }
 
+    private static void ReplaceAgentLlmAdapter(IServiceCollection services)
+    {
+        var descriptorsToRemove = services
+            .Where(d => d.ServiceType == typeof(ILlmAdapter))
+            .ToList();
+        foreach (var descriptor in descriptorsToRemove)
+            services.Remove(descriptor);
+
+        services.AddScoped<ILlmAdapter, DeterministicAgentLlmAdapter>();
+    }
+
     private static void ConfigureTestAuth(IServiceCollection services)
     {
         services.Configure<AuthConfiguration>(opts =>
@@ -135,5 +149,33 @@ public class ChronosApiFactory : WebApplicationFactory<AuthConfiguration>
         var scope = Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         return (scope, db);
+    }
+
+    private sealed class DeterministicAgentLlmAdapter : ILlmAdapter
+    {
+        public Task<LlmResponse> ChatAsync(
+            IReadOnlyList<ChatMessage> messages,
+            LlmOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (options?.JsonMode == true)
+            {
+                const string extractedDraft = """
+                {
+                  "hardConstraints": [
+                    { "key": "forbidden_timerange", "value": "Friday 09:00 - 17:00" }
+                  ],
+                  "softPreferences": [
+                    { "key": "preferred_weekday", "value": "Monday" }
+                  ]
+                }
+                """;
+
+                return Task.FromResult(new LlmResponse(extractedDraft));
+            }
+
+            return Task.FromResult(new LlmResponse(
+                "Got it. I will draft an unavailable Friday time range and a Monday preference."));
+        }
     }
 }

--- a/tests/Chronos.Tests.Acceptance/README.md
+++ b/tests/Chronos.Tests.Acceptance/README.md
@@ -1,0 +1,99 @@
+# Chronos Acceptance Tests
+
+This project contains full-stack acceptance tests for the Chronos API. Tests run
+through the real ASP.NET Core HTTP pipeline by using `ChronosApiFactory`, with
+external infrastructure replaced by deterministic test doubles:
+
+- PostgreSQL is replaced with EF Core InMemory.
+- RabbitMQ publishing is replaced with an `IMessagePublisher` substitute.
+- LLM calls are replaced with a deterministic Agent adapter.
+- Auth tokens are generated with the same issuer/audience/signing-key shape used
+  by the application.
+
+Acceptance tests should prove user-visible behavior and business workflows. They
+should not become an endpoint inventory.
+
+## Structure
+
+```text
+tests/Chronos.Tests.Acceptance/
+├── Infrastructure/        # Test host, HTTP helpers, token generator
+├── Support/               # AcceptanceContext, Seeder, shared constants
+└── Flows/                 # Acceptance flows grouped by product capability
+    ├── Agent/
+    ├── Appeals/
+    ├── Authentication/
+    ├── Authorization/
+    ├── Constraints/
+    ├── Health/
+    ├── OrganizationManagement/
+    ├── Scheduling/
+    └── UserRoleAdmin/
+```
+
+`Infrastructure/` should stay plumbing-only. Do not place `[Test]` classes there.
+
+`Flows/<Capability>/` is the home for acceptance tests. Add a new folder when a
+new product capability needs a user-facing flow.
+
+## Support Helpers
+
+Use `AcceptanceContext` when a test needs a ready organization and authenticated
+administrator:
+
+```csharp
+using var ctx = await AcceptanceContext.CreateAsync("My Acceptance Org");
+var department = await ctx.Seed.CreateDepartmentAsync("Engineering");
+```
+
+`AcceptanceContext` handles:
+
+- booting a fresh API host,
+- registering a new organization and admin user,
+- attaching the bearer token,
+- setting the `x-org-id` header,
+- exposing `ctx.Seed` for API-driven setup.
+
+Use `ctx.CreateClientAs(role)` for role-specific authorization scenarios, but do
+not add negative RBAC assertions until the role hierarchy bug is fixed.
+
+Use `Seeder` for setup data that is not the behavior under test. Keep seeders
+thin and API-driven. Feature-specific seed methods can live in partial files such
+as `Seeder.Scheduling.cs` when they are reused by more than one flow.
+
+## When Not To Use AcceptanceContext
+
+Do not use `AcceptanceContext` in tests that are directly proving registration,
+login, refresh, or token validation. `AcceptanceContext` depends on registration
+working, so auth primitive tests should use `ChronosApiFactory` directly.
+
+This keeps auth tests honest and avoids circular setup.
+
+## Test Quality Bar
+
+Prefer one meaningful workflow over many tiny endpoint checks.
+
+Good acceptance tests usually answer one of these questions:
+
+- Can a user complete a real workflow?
+- Does the system expose the resulting state in the places users rely on?
+- Is an important invalid action rejected?
+- Does a cross-cutting concern, such as tenant isolation, hold end-to-end?
+
+Avoid tests that only say "POST works", "PATCH works", and "DELETE works" unless
+that CRUD sequence is itself the user requirement. Low-level validation branches
+belong in unit tests.
+
+Keep assertions on durable behavior: status codes, persisted fields, published
+messages, and returned DTOs. Avoid asserting human-readable error strings unless
+the API has no structured error contract yet.
+
+## Current Scope Decisions
+
+- Agent acceptance uses a deterministic LLM adapter from `ChronosApiFactory`.
+  Do not call real LLM providers from acceptance tests.
+- Negative authorization/RBAC acceptance tests are deferred until the known role
+  hierarchy bug is fixed. In particular, the `Operator` role currently grants too
+  much access, so tests for lower-role `403` behavior would be misleading or red.
+- The remaining acceptance suite should focus on product flows, not exhaustive
+  CRUD coverage. Exhaustive edge cases belong in the relevant unit-test projects.

--- a/tests/Chronos.Tests.Acceptance/Support/Seeder.Scheduling.cs
+++ b/tests/Chronos.Tests.Acceptance/Support/Seeder.Scheduling.cs
@@ -74,10 +74,11 @@ public sealed partial class Seeder
     {
         var suffix = Guid.NewGuid().ToString("N")[..8];
         var dept = await CreateDepartmentAsync($"Activity Dept {suffix}");
+        var from = DateTime.UtcNow.Date.AddDays(30);
         var period = await CreateSchedulingPeriodAsync(
             $"Activity Period {suffix}",
-            new DateTime(2026, 9, 1),
-            new DateTime(2027, 1, 31));
+            from,
+            from.AddMonths(4));
         var instructor = await CreateUserAsync($"activity-instructor-{suffix}@chronos.test");
         var subject = await CreateSubjectAsync(
             organizationId,


### PR DESCRIPTION
## Description

Adds final polish for the Chronos acceptance-test suite and adds deterministic Agent acceptance coverage. The Agent flow now verifies the meaningful user path: start a session, send scheduling preferences, submit the generated draft, approve it, and verify the resulting constraint/preference through the schedule APIs.

## Related Issues

Closes bgu-nasa/main#126

## Changes Made

- Added `tests/Chronos.Tests.Acceptance/Flows/Agent/AgentSubmissionTests.cs`
  - covers Agent session start
  - sends a scheduling preference message
  - submits the extracted draft
  - approves the draft
  - verifies persisted `UserConstraint` and `UserPreference`
- Updated `ChronosApiFactory`
  - replaces real `ILlmAdapter` registrations with a deterministic test adapter
  - keeps Agent acceptance tests stable and independent from real LLM providers
- Added `tests/Chronos.Tests.Acceptance/README.md`
  - documents Infrastructure / Support / Flows structure
  - explains when to use `AcceptanceContext`
  - explains when not to use it, especially auth primitive tests
  - documents Seeder conventions
  - defines the acceptance-test quality bar
  - notes RBAC is still deferred
- Updated `Seeder.Scheduling.CreateActivityWithPrerequisitesAsync`
  - replaced hardcoded 2026/2027 period dates with future dates relative to `DateTime.UtcNow`

## Testing

- [x] Acceptance tests pass
- [x] No production changes

### Test Instructions

`dotnet test tests/Chronos.Tests.Acceptance/Chronos.Tests.Acceptance.csproj --nologo -v q`

Result: 47 passed, 0 failed.

## Database Changes

- [x] No database changes

## Configuration Changes

- [x] No configuration changes required

## Additional Context

- This PR intentionally does not add RBAC/authorization acceptance tests. Those remain deferred until the known role hierarchy bug is fixed.
- Agent acceptance uses a deterministic LLM adapter in the test host, so the suite does not call real LLM providers.