### PR TITLE
feat(engine): add PeriodWeekCalculator

### DIFF
--- a/src/Chronos.Engine/Matching/PeriodWeekCalculator.cs
+++ b/src/Chronos.Engine/Matching/PeriodWeekCalculator.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+
+namespace Chronos.Engine.Matching;
+
+/// <summary>
+/// Period-relative week indices (1..N) aligned with the calendar's Sunday-start week view.
+/// Stored in <see cref="Domain.Schedule.Assignment.WeekNum"/> during batch scheduling.
+/// </summary>
+public static class PeriodWeekCalculator
+{
+    public static DateTime GetSundayWeekStart(DateTime date)
+    {
+        var d = date.Date;
+        return d.AddDays(-(int)d.DayOfWeek);
+    }
+
+    public static IReadOnlyList<int> GetPeriodWeekIndices(DateTime periodFrom, DateTime periodTo)
+    {
+        var weeks = new List<int>();
+        var weekStart = GetSundayWeekStart(periodFrom);
+        var end = periodTo.Date;
+        var index = 1;
+
+        while (weekStart <= end)
+        {
+            var weekEnd = weekStart.AddDays(6);
+            if (weekEnd >= periodFrom.Date && weekStart <= end)
+            {
+                weeks.Add(index);
+            }
+
+            index++;
+            weekStart = weekStart.AddDays(7);
+        }
+
+        return weeks;
+    }
+
+    public static int GetPeriodWeekIndex(DateTime periodFrom, DateTime date)
+    {
+        var periodStartSunday = GetSundayWeekStart(periodFrom);
+        var weekStart = GetSundayWeekStart(date);
+        if (weekStart < periodStartSunday)
+        {
+            return 1;
+        }
+
+        return (weekStart - periodStartSunday).Days / 7 + 1;
+    }
+
+    public static (DateTime WeekStart, DateTime WeekEnd) GetPeriodWeekDateRange(
+        DateTime periodFrom,
+        int periodWeekIndex
+    )
+    {
+        var periodStartSunday = GetSundayWeekStart(periodFrom);
+        var weekStart = periodStartSunday.AddDays((periodWeekIndex - 1) * 7);
+        return (weekStart, weekStart.AddDays(6));
+    }
+
+    public static HashSet<int> GetIsoWeekNumbersOverlappingPeriodWeek(
+        DateTime periodFrom,
+        int periodWeekIndex
+    )
+    {
+        var (weekStart, weekEnd) = GetPeriodWeekDateRange(periodFrom, periodWeekIndex);
+        var isoWeeks = new HashSet<int>();
+        for (var d = weekStart; d <= weekEnd; d = d.AddDays(1))
+        {
+            isoWeeks.Add(ISOWeek.GetWeekOfYear(d));
+        }
+
+        return isoWeeks;
+    }
+
+    /// <summary>
+    /// Returns true when a constraint's week scope applies to batch scheduling week
+    /// <paramref name="schedulingWeekNum"/> (period index). Supports constraints stored as
+    /// either period week index or legacy ISO week number.
+    /// </summary>
+    public static bool ConstraintWeekApplies(
+        int? constraintWeekNum,
+        int schedulingWeekNum,
+        DateTime? periodFrom
+    )
+    {
+        if (!constraintWeekNum.HasValue)
+        {
+            return true;
+        }
+
+        if (!periodFrom.HasValue)
+        {
+            return constraintWeekNum.Value == schedulingWeekNum;
+        }
+
+        if (constraintWeekNum.Value == schedulingWeekNum)
+        {
+            return true;
+        }
+
+        return GetIsoWeekNumbersOverlappingPeriodWeek(periodFrom.Value, schedulingWeekNum)
+            .Contains(constraintWeekNum.Value);
+    }
+}

--- a/tests/Chronos.Tests.Engine/Specification/PeriodWeekCalculatorTests.cs
+++ b/tests/Chronos.Tests.Engine/Specification/PeriodWeekCalculatorTests.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using Chronos.Engine.Matching;
+
+namespace Chronos.Tests.Engine.Specification;
+
+[TestFixture]
+[Category("Specification")]
+public class PeriodWeekCalculatorTests
+{
+    [Test]
+    public void SundayAndMondayInSameCalendarWeek_sharePeriodWeekIndex_notIsoWeek()
+    {
+        var periodFrom = new DateTime(2026, 6, 1);
+        var sunday = new DateTime(2026, 6, 21);
+        var monday = new DateTime(2026, 6, 22);
+
+        var isoSunday = ISOWeek.GetWeekOfYear(sunday);
+        var isoMonday = ISOWeek.GetWeekOfYear(monday);
+        isoSunday.Should().NotBe(isoMonday, "ISO weeks split Sunday vs Monday at year boundaries");
+
+        var periodWeekSunday = PeriodWeekCalculator.GetPeriodWeekIndex(periodFrom, sunday);
+        var periodWeekMonday = PeriodWeekCalculator.GetPeriodWeekIndex(periodFrom, monday);
+        periodWeekSunday.Should().Be(periodWeekMonday,
+            "calendar week view uses one period week index for Sun–Sat");
+    }
+}


### PR DESCRIPTION
## Summary
Adds Sunday-start period-relative week index utility and unit test.

Relates to bgu-nasa/main#134

## Test plan
- [x] `dotnet test Chronos.sln --configuration Release`