### PR TITLE
fix(engine): enforce enrollment capacity without required_capacity row

### DIFF
--- a/src/Chronos.Data/ModelConfig/Resources/ActivityConfiguration.cs
+++ b/src/Chronos.Data/ModelConfig/Resources/ActivityConfiguration.cs
@@ -23,5 +23,8 @@ public class ActivityConfiguration : IEntityTypeConfiguration<Activity>
             .HasMaxLength(128);
 
         builder.Property(a => a.ExpectedStudents);
+
+        builder.Property(a => a.Duration)
+            .IsRequired();
     }
 }

--- a/src/Chronos.Engine/Constraints/Evaluation/ConstraintEvaluator.cs
+++ b/src/Chronos.Engine/Constraints/Evaluation/ConstraintEvaluator.cs
@@ -58,6 +58,13 @@ public class ConstraintEvaluator : IConstraintEvaluator
                 .ToList();
         }
 
+        // ASSIGNMENT_ALGORITHM §2.3: always enforce ExpectedStudents vs capacity when no
+        // required_capacity row applies (validator also checks enrollment when that row exists).
+        if (!constraints.Any(c => c.Key == "required_capacity"))
+        {
+            violations.AddRange(EvaluateEnrollmentCapacity(activity, resource));
+        }
+
         _logger.LogInformation(
             "Evaluating {ConstraintCount} constraints for Activity {ActivityId} with Slot {SlotId} and Resource {ResourceId}",
             constraints.Count,
@@ -105,5 +112,54 @@ public class ConstraintEvaluator : IConstraintEvaluator
         );
 
         return violations;
+    }
+
+    /// <summary>
+    /// ASSIGNMENT_ALGORITHM §2.3: always enforce ExpectedStudents vs room capacity,
+    /// independent of whether a <c>required_capacity</c> constraint row exists.
+    /// </summary>
+    private static IEnumerable<ConstraintViolation> EvaluateEnrollmentCapacity(
+        Activity activity,
+        Resource resource
+    )
+    {
+        if (!activity.ExpectedStudents.HasValue)
+        {
+            yield break;
+        }
+
+        var expected = activity.ExpectedStudents.Value;
+
+        if (!resource.Capacity.HasValue)
+        {
+            yield return new ConstraintViolation
+            {
+                ConstraintKey = "enrollment_capacity",
+                ConstraintValue = expected.ToString(),
+                ViolationType = ViolationType.Hard,
+                Severity = ViolationSeverity.Error,
+                Message =
+                    $"Resource '{resource.Identifier}' does not have capacity information for {expected} expected students",
+                Details =
+                    $"Expected students: {expected}, Resource capacity: null",
+            };
+            yield break;
+        }
+
+        var capacity = resource.Capacity.Value;
+        if (capacity < expected)
+        {
+            yield return new ConstraintViolation
+            {
+                ConstraintKey = "enrollment_capacity",
+                ConstraintValue = expected.ToString(),
+                ViolationType = ViolationType.Hard,
+                Severity = ViolationSeverity.Error,
+                Message =
+                    $"Resource capacity ({capacity}) is insufficient for expected students ({expected})",
+                Details =
+                    $"Expected students: {expected}, Resource capacity: {capacity}, Resource: {resource.Identifier}",
+            };
+        }
     }
 }

--- a/src/Chronos.Engine/Constraints/Evaluation/ConstraintEvaluator.cs
+++ b/src/Chronos.Engine/Constraints/Evaluation/ConstraintEvaluator.cs
@@ -58,8 +58,8 @@ public class ConstraintEvaluator : IConstraintEvaluator
                 .ToList();
         }
 
-        // ASSIGNMENT_ALGORITHM §2.3: always enforce ExpectedStudents vs capacity when no
-        // required_capacity row applies (validator also checks enrollment when that row exists).
+        // Always enforce ExpectedStudents vs capacity when no required_capacity row exists
+        // (RequiredCapacityValidator also runs when that row is present).
         if (!constraints.Any(c => c.Key == "required_capacity"))
         {
             violations.AddRange(EvaluateEnrollmentCapacity(activity, resource));
@@ -115,8 +115,8 @@ public class ConstraintEvaluator : IConstraintEvaluator
     }
 
     /// <summary>
-    /// ASSIGNMENT_ALGORITHM §2.3: always enforce ExpectedStudents vs room capacity,
-    /// independent of whether a <c>required_capacity</c> constraint row exists.
+    /// Always enforce ExpectedStudents vs room capacity, independent of whether a
+    /// <c>required_capacity</c> constraint row exists.
     /// </summary>
     private static IEnumerable<ConstraintViolation> EvaluateEnrollmentCapacity(
         Activity activity,

--- a/src/Chronos.Engine/Matching/PeriodWeekCalculator.cs
+++ b/src/Chronos.Engine/Matching/PeriodWeekCalculator.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+
+namespace Chronos.Engine.Matching;
+
+/// <summary>
+/// Period-relative week indices (1..N) aligned with the calendar's Sunday-start week view.
+/// Stored in <see cref="Domain.Schedule.Assignment.WeekNum"/> during batch scheduling.
+/// </summary>
+public static class PeriodWeekCalculator
+{
+    public static DateTime GetSundayWeekStart(DateTime date)
+    {
+        var d = date.Date;
+        return d.AddDays(-(int)d.DayOfWeek);
+    }
+
+    public static IReadOnlyList<int> GetPeriodWeekIndices(DateTime periodFrom, DateTime periodTo)
+    {
+        var weeks = new List<int>();
+        var weekStart = GetSundayWeekStart(periodFrom);
+        var end = periodTo.Date;
+        var index = 1;
+
+        while (weekStart <= end)
+        {
+            var weekEnd = weekStart.AddDays(6);
+            if (weekEnd >= periodFrom.Date && weekStart <= end)
+            {
+                weeks.Add(index);
+            }
+
+            index++;
+            weekStart = weekStart.AddDays(7);
+        }
+
+        return weeks;
+    }
+
+    public static int GetPeriodWeekIndex(DateTime periodFrom, DateTime date)
+    {
+        var periodStartSunday = GetSundayWeekStart(periodFrom);
+        var weekStart = GetSundayWeekStart(date);
+        if (weekStart < periodStartSunday)
+        {
+            return 1;
+        }
+
+        return (weekStart - periodStartSunday).Days / 7 + 1;
+    }
+
+    public static (DateTime WeekStart, DateTime WeekEnd) GetPeriodWeekDateRange(
+        DateTime periodFrom,
+        int periodWeekIndex
+    )
+    {
+        var periodStartSunday = GetSundayWeekStart(periodFrom);
+        var weekStart = periodStartSunday.AddDays((periodWeekIndex - 1) * 7);
+        return (weekStart, weekStart.AddDays(6));
+    }
+
+    public static HashSet<int> GetIsoWeekNumbersOverlappingPeriodWeek(
+        DateTime periodFrom,
+        int periodWeekIndex
+    )
+    {
+        var (weekStart, weekEnd) = GetPeriodWeekDateRange(periodFrom, periodWeekIndex);
+        var isoWeeks = new HashSet<int>();
+        for (var d = weekStart; d <= weekEnd; d = d.AddDays(1))
+        {
+            isoWeeks.Add(ISOWeek.GetWeekOfYear(d));
+        }
+
+        return isoWeeks;
+    }
+
+    /// <summary>
+    /// Returns true when a constraint's week scope applies to batch scheduling week
+    /// <paramref name="schedulingWeekNum"/> (period index). Supports constraints stored as
+    /// either period week index or legacy ISO week number.
+    /// </summary>
+    public static bool ConstraintWeekApplies(
+        int? constraintWeekNum,
+        int schedulingWeekNum,
+        DateTime? periodFrom
+    )
+    {
+        if (!constraintWeekNum.HasValue)
+        {
+            return true;
+        }
+
+        if (!periodFrom.HasValue)
+        {
+            return constraintWeekNum.Value == schedulingWeekNum;
+        }
+
+        if (constraintWeekNum.Value == schedulingWeekNum)
+        {
+            return true;
+        }
+
+        return GetIsoWeekNumbersOverlappingPeriodWeek(periodFrom.Value, schedulingWeekNum)
+            .Contains(constraintWeekNum.Value);
+    }
+}

--- a/tests/Chronos.Tests.Engine/Integration/ConstraintEvaluatorIntegrationTests.cs
+++ b/tests/Chronos.Tests.Engine/Integration/ConstraintEvaluatorIntegrationTests.cs
@@ -67,6 +67,22 @@ public class ConstraintEvaluatorIntegrationTests
     }
 
     [Test]
+    public async Task CanAssignAsync_WhenExpectedStudentsExceedCapacity_withoutRequiredCapacityConstraint_ShouldReturnFalse()
+    {
+        var activity = TestDataBuilder.CreateActivity(expectedStudents: 30);
+        var slot = TestDataBuilder.CreateSlot();
+        var resource = TestDataBuilder.CreateResource(capacity: 15);
+
+        _constraintRepository
+            .GetByActivityIdAsync(activity.Id)
+            .Returns(new List<Domain.Schedule.ActivityConstraint>());
+
+        var canAssign = await _evaluator.CanAssignAsync(activity, slot, resource);
+
+        canAssign.Should().BeFalse();
+    }
+
+    [Test]
     public async Task CanAssignAsync_WithNoConstraints_ShouldReturnTrue()
     {
         // Arrange

--- a/tests/Chronos.Tests.Engine/Specification/PeriodWeekCalculatorTests.cs
+++ b/tests/Chronos.Tests.Engine/Specification/PeriodWeekCalculatorTests.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using Chronos.Engine.Matching;
+
+namespace Chronos.Tests.Engine.Specification;
+
+[TestFixture]
+[Category("Specification")]
+public class PeriodWeekCalculatorTests
+{
+    [Test]
+    public void SundayAndMondayInSameCalendarWeek_sharePeriodWeekIndex_notIsoWeek()
+    {
+        var periodFrom = new DateTime(2026, 6, 1);
+        var sunday = new DateTime(2026, 6, 21);
+        var monday = new DateTime(2026, 6, 22);
+
+        var isoSunday = ISOWeek.GetWeekOfYear(sunday);
+        var isoMonday = ISOWeek.GetWeekOfYear(monday);
+        isoSunday.Should().NotBe(isoMonday, "ISO weeks split Sunday vs Monday at year boundaries");
+
+        var periodWeekSunday = PeriodWeekCalculator.GetPeriodWeekIndex(periodFrom, sunday);
+        var periodWeekMonday = PeriodWeekCalculator.GetPeriodWeekIndex(periodFrom, monday);
+        periodWeekSunday.Should().Be(periodWeekMonday,
+            "calendar week view uses one period week index for Sun–Sat");
+    }
+}


### PR DESCRIPTION
## Summary
Enforces ExpectedStudents vs room capacity when no required_capacity constraint row exists. Marks Activity.Duration required in EF config.

Relates to bgu-nasa/main#135

## Test plan
- [x] dotnet test Chronos.sln --configuration Release