### PR TITLE
Make assignment week number optional on create and update

### DIFF
--- a/src/Chronos.MainApi/Schedule/Contracts/CreateAssignmentRequest.cs
+++ b/src/Chronos.MainApi/Schedule/Contracts/CreateAssignmentRequest.cs
@@ -4,4 +4,4 @@ public record CreateAssignmentRequest(
     Guid SlotId,
     Guid ResourceId,
     Guid ActivityId,
-    int WeekNum);
+    int? WeekNum);

--- a/src/Chronos.MainApi/Schedule/Contracts/UpdateAssignmentRequest.cs
+++ b/src/Chronos.MainApi/Schedule/Contracts/UpdateAssignmentRequest.cs
@@ -4,4 +4,4 @@ public record UpdateAssignmentRequest(
     Guid SlotId,
     Guid ResourceId,
     Guid ActivityId,
-    int WeekNum);
+    int? WeekNum);

--- a/src/Chronos.MainApi/Schedule/Services/AssignmentService.cs
+++ b/src/Chronos.MainApi/Schedule/Services/AssignmentService.cs
@@ -15,7 +15,7 @@ public class AssignmentService(
     ISchedulingPeriodService schedulingPeriodService,
     ILogger<AssignmentService> logger) : IAssignmentService
 {
-    public async Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid activityId, int weekNum)
+    public async Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid activityId, int? weekNum)
     {
         logger.LogInformation(
             "Creating assignment. OrganizationId: {OrganizationId}, SlotId: {SlotId}, ResourceId: {ResourceId}, ActivityId: {ActivityId}",
@@ -139,7 +139,7 @@ public class AssignmentService(
         return assignment;
     }
     
-    public async Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId, Guid activityId, int weekNum)
+    public async Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId, Guid activityId, int? weekNum)
     {
         logger.LogInformation(
             "Updating assignment. OrganizationId: {OrganizationId}, AssignmentId: {AssignmentId}",
@@ -256,7 +256,7 @@ public class AssignmentService(
         Guid organizationId,
         Guid slotId,
         Guid resourceId,
-        int weekNum,
+        int? weekNum,
         Guid? excludeAssignmentId = null)
     {
         var slot = await slotService.GetSlotAsync(organizationId, slotId);
@@ -273,7 +273,7 @@ public class AssignmentService(
                 continue;
             }
 
-            if (assignment.WeekNum.HasValue && assignment.WeekNum.Value != weekNum)
+            if (weekNum.HasValue && assignment.WeekNum.HasValue && assignment.WeekNum.Value != weekNum.Value)
             {
                 continue;
             }

--- a/src/Chronos.MainApi/Schedule/Services/IAssignmentService.cs
+++ b/src/Chronos.MainApi/Schedule/Services/IAssignmentService.cs
@@ -4,7 +4,7 @@ namespace Chronos.MainApi.Schedule.Services;
 
 public interface IAssignmentService
 {
-    Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid ScheduledItemId, int weekNum);
+    Task<Guid> CreateAssignmentAsync(Guid organizationId, Guid slotId, Guid resourceId, Guid ScheduledItemId, int? weekNum);
     
     Task<Assignment> GetAssignmentAsync(Guid organizationId, Guid assignmentId);
     
@@ -22,7 +22,7 @@ public interface IAssignmentService
     
     Task<Assignment?> GetAssignmentBySlotAndResourceItemAsync(Guid organizationId, Guid slotId, Guid resourceId);
     
-    Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId , Guid activityId, int weekNum);
+    Task UpdateAssignmentAsync(Guid organizationId, Guid assignmentId, Guid slotId, Guid resourceId , Guid activityId, int? weekNum);
     
     Task DeleteAssignmentAsync(Guid organizationId, Guid assignmentId);
     Task DeleteAssignmentsBySchedulingPeriodAsync(Guid organizationId, Guid schedulingPeriodId);


### PR DESCRIPTION
## Summary

Allow assignments to be created and updated without a week number by making `WeekNum` nullable on the assignment write path. This aligns the API with the existing domain model (`int? WeekNum`), database schema, and GET responses.

Also fixes conflict validation so “all weeks” assignments are checked against overlapping assignments on the same resource, regardless of the other assignment’s week.

## Changes

- `CreateAssignmentRequest` — `WeekNum` changed from `int` to `int?`
- `UpdateAssignmentRequest` — `WeekNum` changed from `int` to `int?`
- `IAssignmentService` / `AssignmentService` — create and update methods accept `int? weekNum`
- `ValidateNoConflictingAssignmentAsync` — only skip conflict checks when **both** assignments have a specific week and they differ

## Why

Previously, omitting `weekNum` defaulted to `0` and sending `null` failed model binding. The read path and calendar already supported null week numbers; this completes support on the write path.

## Test plan

- [ ] Create an assignment via API with `"weekNum": null` — returns 201 and response has `"weekNum": null`
- [ ] Create an assignment with a valid week number (e.g. `5`) — still works
- [ ] Update an assignment to clear `weekNum` — persists as null
- [ ] Creating an all-weeks assignment on a resource/slot that already has an overlapping assignment returns 400
- [ ] Creating week-specific assignments on different weeks for the same non-overlapping slots still succeeds
- [ ] `dotnet test` — AssignmentService unit tests pass

## Related

- Depends on / pairs with: **Chronos.WebApplication** PR below
- Frontend should not be merged before this API change is available in the target environment