### PR TITLE
Fix lecturer double-booking and inconsistent week-to-week slot assignments

### DIFF
--- a/src/Chronos.Engine/Matching/OnlineMatchingStrategy.cs
+++ b/src/Chronos.Engine/Matching/OnlineMatchingStrategy.cs
@@ -155,21 +155,75 @@ public class OnlineMatchingStrategy(
             );
         }
 
-        var modifiedCount = 0;
-        var unresolved = false;
+        var schedulingPeriod = await _dbContext.SchedulingPeriods
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.Id == schedulingPeriodId, cancellationToken);
 
-        foreach (var weekGroup in assignments.GroupBy(a => a.WeekNum))
+        List<int?> weeks;
+        if (assignments.Any(a => a.WeekNum == null))
         {
-            var weekNum = weekGroup.Key;
-            var weekAssignments = weekGroup.ToList();
-            var excludedSlots = await GetExcludedSlotsAsync(
+            weeks = new List<int?> { null };
+        }
+        else if (schedulingPeriod != null)
+        {
+            weeks = PeriodWeekCalculator.GetPeriodWeekIndices(schedulingPeriod.FromDate, schedulingPeriod.ToDate)
+                .Select(w => (int?)w)
+                .ToList();
+        }
+        else
+        {
+            weeks = assignments.Select(a => a.WeekNum).Distinct().ToList();
+        }
+
+        var slots = await _dbContext
+            .Slots.IgnoreQueryFilters()
+            .Where(s => s.SchedulingPeriodId == schedulingPeriodId)
+            .Where(s => s.OrganizationId == request.OrganizationId)
+            .ToListAsync(cancellationToken);
+        var resources = await _dbContext
+            .Resources.IgnoreQueryFilters()
+            .Where(r => r.OrganizationId == request.OrganizationId)
+            .ToListAsync(cancellationToken);
+
+        // Pre-fetch excluded slots for each week
+        var weekExcludedSlots = new Dictionary<int, HashSet<Guid>>();
+        foreach (var weekNum in weeks)
+        {
+            weekExcludedSlots[weekNum ?? -1] = await GetExcludedSlotsAsync(
                 activity,
                 request.OrganizationId,
                 schedulingPeriodId,
                 weekNum
             );
+        }
 
-            if (await IsPartialAssignmentStreakAsync(activity, weekAssignments, cancellationToken))
+        var dbAssignments = (await _assignmentRepository.GetBySchedulingPeriodIdAsync(schedulingPeriodId)) ?? new List<Assignment>();
+        var currentAssignmentIds = assignments.Select(a => a.Id).ToHashSet();
+        var activityIds = dbAssignments.Select(a => a.ActivityId).Distinct().ToList();
+        var teachersMap = await _dbContext.Activities
+            .IgnoreQueryFilters()
+            .Where(a => a.OrganizationId == request.OrganizationId && activityIds.Contains(a.Id))
+            .Where(a => a.AssignedUserId != Guid.Empty)
+            .ToDictionaryAsync(a => a.Id, a => a.AssignedUserId, cancellationToken);
+
+        var preferredSlotResource = await FindBestConsistentSlotResourceAsync(
+            activity,
+            assignments,
+            weeks,
+            request.OrganizationId,
+            schedulingPeriodId,
+            cancellationToken
+        );
+
+        var modifiedCount = 0;
+        var unresolved = false;
+
+        foreach (var weekNum in weeks)
+        {
+            var weekAssignments = assignments.Where(a => a.WeekNum == weekNum).ToList();
+            var excludedSlots = weekExcludedSlots.TryGetValue(weekNum ?? -1, out var excl) ? excl : new HashSet<Guid>();
+
+            if (weekAssignments.Any() && await IsPartialAssignmentStreakAsync(activity, weekAssignments, cancellationToken))
             {
                 foreach (var assignment in weekAssignments.ToList())
                 {
@@ -188,6 +242,15 @@ public class OnlineMatchingStrategy(
                 cancellationToken
             );
 
+            if (isValid && preferredSlotResource != null && weekAssignments.Any())
+            {
+                if (weekAssignments[0].SlotId != preferredSlotResource.SlotId ||
+                    weekAssignments[0].ResourceId != preferredSlotResource.ResourceId)
+                {
+                    isValid = false;
+                }
+            }
+
             if (isValid)
             {
                 continue;
@@ -200,12 +263,18 @@ public class OnlineMatchingStrategy(
                 excludedSlots,
                 request.OrganizationId,
                 schedulingPeriodId,
+                weekNum,
                 request.InitiatedByUserId,
+                preferredSlotResource,
                 cancellationToken
             );
 
-            modifiedCount += rescheduleResult.AssignmentsModified;
-            if (!rescheduleResult.Success)
+            if (rescheduleResult.Success)
+            {
+                modifiedCount += rescheduleResult.AssignmentsModified;
+                preferredSlotResource ??= rescheduleResult.SelectedAnchor;
+            }
+            else
             {
                 unresolved = true;
             }
@@ -281,9 +350,9 @@ public class OnlineMatchingStrategy(
             );
         }
 
-        var assignments = await _assignmentRepository.GetBySchedulingPeriodIdAsync(
+        var assignments = (await _assignmentRepository.GetBySchedulingPeriodIdAsync(
             request.SchedulingPeriodId
-        );
+        )) ?? new List<Assignment>();
 
         if (!assignments.Any())
         {
@@ -337,49 +406,129 @@ public class OnlineMatchingStrategy(
             }
 
             var activity = activitiesById[activityId];
-            var currentAssignments = await GetOrderedAssignmentsByActivityAsync(
+            var allCurrentAssignments = await GetOrderedAssignmentsByActivityAsync(
                 activity.Id,
                 cancellationToken
             );
 
-            if (!currentAssignments.Any())
+            if (!allCurrentAssignments.Any())
             {
                 continue;
             }
 
-            var excludedSlots = await GetExcludedSlotsAsync(
-                activity,
-                request.OrganizationId,
-                request.SchedulingPeriodId
-            );
+            var schedulingPeriod = await _dbContext.SchedulingPeriods
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(p => p.Id == request.SchedulingPeriodId, cancellationToken);
 
-            var isValid = await IsAssignmentSetValidAsync(
-                activity,
-                currentAssignments,
-                excludedSlots,
-                null,
-                cancellationToken
-            );
-            if (isValid)
+            List<int?> weeks;
+            if (allCurrentAssignments.Any(a => a.WeekNum == null))
             {
-                continue;
+                weeks = new List<int?> { null };
+            }
+            else if (schedulingPeriod != null)
+            {
+                weeks = PeriodWeekCalculator.GetPeriodWeekIndices(schedulingPeriod.FromDate, schedulingPeriod.ToDate)
+                    .Select(w => (int?)w)
+                    .ToList();
+            }
+            else
+            {
+                weeks = allCurrentAssignments.Select(a => a.WeekNum).Distinct().ToList();
             }
 
-            var rematchResult = await TryRescheduleAssignmentAsync(
-                request.ActivityConstraintId,
+            var preferredSlotResource = await FindBestConsistentSlotResourceAsync(
                 activity,
-                currentAssignments,
-                excludedSlots,
+                allCurrentAssignments,
+                weeks,
                 request.OrganizationId,
                 request.SchedulingPeriodId,
-                request.InitiatedByUserId,
                 cancellationToken
             );
 
-            modifiedCount += rematchResult.AssignmentsModified;
-            if (!rematchResult.Success)
+            foreach (var weekNum in weeks)
             {
-                unresolvedActivityIds.Add(activity.Id);
+                var currentAssignments = allCurrentAssignments.Where(a => a.WeekNum == weekNum).ToList();
+
+                var excludedSlots = await GetExcludedSlotsAsync(
+                    activity,
+                    request.OrganizationId,
+                    request.SchedulingPeriodId,
+                    weekNum
+                );
+
+                if (currentAssignments.Any() && await IsPartialAssignmentStreakAsync(activity, currentAssignments, cancellationToken))
+                {
+                    foreach (var assignment in currentAssignments.ToList())
+                    {
+                        await _assignmentRepository.DeleteAsync(assignment);
+                    }
+                    if (!unresolvedActivityIds.Contains(activity.Id))
+                    {
+                        unresolvedActivityIds.Add(activity.Id);
+                    }
+                    continue;
+                }
+
+                var isValid = await IsAssignmentSetValidAsync(
+                    activity,
+                    currentAssignments,
+                    excludedSlots,
+                    weekNum,
+                    cancellationToken
+                );
+
+                if (isValid && preferredSlotResource != null && currentAssignments.Any())
+                {
+                    if (currentAssignments[0].SlotId != preferredSlotResource.SlotId ||
+                        currentAssignments[0].ResourceId != preferredSlotResource.ResourceId)
+                    {
+                        isValid = false;
+                    }
+                }
+
+                if (isValid)
+                {
+                    continue;
+                }
+
+                var rematchResult = await TryRescheduleAssignmentAsync(
+                    request.ActivityConstraintId,
+                    activity,
+                    currentAssignments,
+                    excludedSlots,
+                    request.OrganizationId,
+                    request.SchedulingPeriodId,
+                    weekNum,
+                    request.InitiatedByUserId,
+                    preferredSlotResource,
+                    cancellationToken
+                );
+
+                if (rematchResult.Success)
+                {
+                    modifiedCount += rematchResult.AssignmentsModified;
+                    preferredSlotResource ??= rematchResult.SelectedAnchor;
+                }
+                else if (!unresolvedActivityIds.Contains(activity.Id))
+                {
+                    unresolvedActivityIds.Add(activity.Id);
+                }
+
+                var remainingForWeek = (await _assignmentRepository.GetByActivityIdAsync(activity.Id))
+                    .Where(a => a.WeekNum == weekNum)
+                    .ToList();
+                if (remainingForWeek.Count > 0
+                    && await IsPartialAssignmentStreakAsync(activity, remainingForWeek, cancellationToken))
+                {
+                    foreach (var assignment in remainingForWeek)
+                    {
+                        await _assignmentRepository.DeleteAsync(assignment);
+                    }
+                    if (!unresolvedActivityIds.Contains(activity.Id))
+                    {
+                        unresolvedActivityIds.Add(activity.Id);
+                    }
+                }
             }
         }
 
@@ -399,25 +548,60 @@ public class OnlineMatchingStrategy(
         );
     }
 
-    private async Task<SchedulingResult> TryRescheduleAssignmentAsync(
+    private record RescheduleResult(
+        bool Success,
+        int AssignmentsModified,
+        SlotResourcePair? SelectedAnchor
+    );
+
+    private async Task<RescheduleResult> TryRescheduleAssignmentAsync(
         Guid requestId,
         Activity activity,
         List<Assignment> currentAssignments,
         HashSet<Guid> excludedSlots,
         Guid organizationId,
         Guid schedulingPeriodId,
+        int? weekNum,
         Guid? initiatedByUserId,
+        SlotResourcePair? preferredSlotResource,
         CancellationToken cancellationToken
     )
     {
-        _logger.LogInformation("Re-matching Activity {ActivityId}", activity.Id);
+        _logger.LogInformation("Re-matching Activity {ActivityId} for week {WeekNum}", activity.Id, weekNum);
 
-        var allAssignments = await _assignmentRepository.GetBySchedulingPeriodIdAsync(schedulingPeriodId);
+        var startAssignment = currentAssignments.FirstOrDefault();
+
+        var allAssignments = (await _assignmentRepository.GetBySchedulingPeriodIdAsync(schedulingPeriodId)) ?? new List<Assignment>();
         var currentAssignmentIds = currentAssignments.Select(a => a.Id).ToHashSet();
         var occupiedPairs = allAssignments
             .Where(a => !currentAssignmentIds.Contains(a.Id))
+            .Where(a => a.WeekNum == weekNum || a.WeekNum == null || weekNum == null)
             .Select(a => (a.SlotId, a.ResourceId))
             .ToHashSet();
+
+        var occupiedTeachers = new HashSet<(Guid SlotId, Guid AssignedUserId)>();
+        if (activity.AssignedUserId != Guid.Empty)
+        {
+            var activityIds = allAssignments
+                .Where(a => !currentAssignmentIds.Contains(a.Id))
+                .Where(a => a.WeekNum == weekNum || a.WeekNum == null || weekNum == null)
+                .Select(a => a.ActivityId)
+                .Distinct()
+                .ToList();
+
+            var teachersMap = await _dbContext.Activities
+                .IgnoreQueryFilters()
+                .Where(a => a.OrganizationId == organizationId && activityIds.Contains(a.Id))
+                .Where(a => a.AssignedUserId != Guid.Empty)
+                .ToDictionaryAsync(a => a.Id, a => a.AssignedUserId, cancellationToken);
+
+            occupiedTeachers = allAssignments
+                .Where(a => !currentAssignmentIds.Contains(a.Id))
+                .Where(a => a.WeekNum == weekNum || a.WeekNum == null || weekNum == null)
+                .Where(a => teachersMap.ContainsKey(a.ActivityId))
+                .Select(a => (a.SlotId, teachersMap[a.ActivityId]))
+                .ToHashSet();
+        }
 
         var slots = await _dbContext
             .Slots.IgnoreQueryFilters()
@@ -429,20 +613,69 @@ public class OnlineMatchingStrategy(
             .Where(r => r.OrganizationId == organizationId)
             .ToListAsync(cancellationToken);
 
-        var startAssignment = currentAssignments[0];
-        var weekNum = startAssignment.WeekNum;
+        // Stage 0: try to use the preferred slot and resource if specified
+        if (preferredSlotResource != null)
+        {
+            var preferredStartSlots = slots.Where(s => s.Id == preferredSlotResource.SlotId && !excludedSlots.Contains(s.Id)).ToList();
+            var preferredResources = resources.Where(r => r.Id == preferredSlotResource.ResourceId).ToList();
+
+            var preferredCandidates = await BuildStreakCandidatesAsync(
+                activity,
+                preferredStartSlots,
+                slots,
+                preferredResources,
+                occupiedPairs,
+                occupiedTeachers,
+                excludedSlots,
+                weekNum,
+                cancellationToken
+            );
+
+            if (preferredCandidates.Any())
+            {
+                var preferredSelection = await SelectCandidateAsync(
+                    preferredCandidates,
+                    activity,
+                    organizationId,
+                    schedulingPeriodId
+                );
+
+                foreach (var assignment in currentAssignments)
+                {
+                    await _assignmentRepository.DeleteAsync(assignment);
+                }
+
+                foreach (var pair in preferredSelection.Streak.OrderBy(p => p.Slot.FromTime))
+                {
+                    await _assignmentRepository.AddAsync(new Assignment
+                    {
+                        Id = Guid.NewGuid(),
+                        OrganizationId = organizationId,
+                        SlotId = pair.SlotId,
+                        ResourceId = pair.ResourceId,
+                        ActivityId = activity.Id,
+                        WeekNum = weekNum,
+                    });
+                }
+
+                return new RescheduleResult(true, 1, preferredSelection.Anchor);
+            }
+        }
 
         // Stage A: try to preserve the starting slot while finding a valid full streak.
-        var sameStartCandidates = await BuildStreakCandidatesAsync(
-            activity,
-            slots.Where(s => s.Id == startAssignment.SlotId && !excludedSlots.Contains(s.Id)).ToList(),
-            slots,
-            resources,
-            occupiedPairs,
-            excludedSlots,
-            weekNum,
-            cancellationToken
-        );
+        var sameStartCandidates = startAssignment != null
+            ? await BuildStreakCandidatesAsync(
+                activity,
+                slots.Where(s => s.Id == startAssignment.SlotId && !excludedSlots.Contains(s.Id)).ToList(),
+                slots,
+                resources,
+                occupiedPairs,
+                occupiedTeachers,
+                excludedSlots,
+                weekNum,
+                cancellationToken
+            )
+            : new List<(SlotResourcePair Anchor, List<SlotResourcePair> Streak)>();
 
         if (sameStartCandidates.Any())
         {
@@ -471,14 +704,10 @@ public class OnlineMatchingStrategy(
                 });
             }
 
-            return new SchedulingResult(
-                requestId,
+            return new RescheduleResult(
                 true,
-                0,
                 1,
-                new List<Guid>(),
-                "Activity successfully re-matched within the same timeslot",
-                initiatedByUserId
+                sameSlotSelection.Anchor
             );
         }
 
@@ -486,12 +715,13 @@ public class OnlineMatchingStrategy(
         var fallbackCandidates = await BuildStreakCandidatesAsync(
             activity,
             slots
-                .Where(s => s.Id != startAssignment.SlotId)
+                .Where(s => startAssignment == null || s.Id != startAssignment.SlotId)
                 .Where(s => !excludedSlots.Contains(s.Id))
                 .ToList(),
             slots,
             resources,
             occupiedPairs,
+            occupiedTeachers,
             excludedSlots,
             weekNum,
             cancellationToken
@@ -509,14 +739,10 @@ public class OnlineMatchingStrategy(
                 await _assignmentRepository.DeleteAsync(assignment);
             }
 
-            return new SchedulingResult(
-                requestId,
+            return new RescheduleResult(
                 false,
                 0,
-                0,
-                new List<Guid> { activity.Id },
-                "Activity could not be rescheduled according to the new constraint. Consider assigning a substitute lecturer or cancelling the activity.",
-                initiatedByUserId
+                null
             );
         }
 
@@ -552,14 +778,10 @@ public class OnlineMatchingStrategy(
             fallbackSelection.Anchor.ResourceId
         );
 
-        return new SchedulingResult(
-            requestId,
+        return new RescheduleResult(
             true,
-            0,
             1,
-            new List<Guid>(),
-            "Activity successfully re-matched",
-            initiatedByUserId
+            fallbackSelection.Anchor
         );
     }
 
@@ -569,6 +791,7 @@ public class OnlineMatchingStrategy(
         List<Slot> allSlots,
         List<Resource> resources,
         HashSet<(Guid SlotId, Guid ResourceId)> occupiedPairs,
+        HashSet<(Guid SlotId, Guid AssignedUserId)> occupiedTeachers,
         HashSet<Guid> excludedSlots,
         int? weekNum,
         CancellationToken cancellationToken
@@ -597,6 +820,12 @@ public class OnlineMatchingStrategy(
                     continue;
                 }
 
+                if (activity.AssignedUserId != Guid.Empty
+                    && occupiedTeachers.Contains((slot.Id, activity.AssignedUserId)))
+                {
+                    continue;
+                }
+
                 var canAssign = await _constraintEvaluator.CanAssignAsync(activity, slot, resource, weekNum);
                 if (!canAssign)
                 {
@@ -611,6 +840,7 @@ public class OnlineMatchingStrategy(
                     orderedAllSlots,
                     excludedSlots,
                     occupiedPairs,
+                    occupiedTeachers,
                     weekNum,
                     cancellationToken
                 );
@@ -782,6 +1012,28 @@ public class OnlineMatchingStrategy(
             }
         }
 
+        // Check if teacher is occupied by another activity at any of these slots
+        if (activity.AssignedUserId != Guid.Empty)
+        {
+            var teacherOccupied = await _dbContext.Assignments
+                .IgnoreQueryFilters()
+                .Where(a => a.WeekNum == weekNum || a.WeekNum == null || weekNum == null)
+                .Where(a => slotIds.Contains(a.SlotId))
+                .Where(a => !assignments.Select(asg => asg.Id).Contains(a.Id))
+                .Join(
+                    _dbContext.Activities.IgnoreQueryFilters().Where(act => act.AssignedUserId == activity.AssignedUserId),
+                    a => a.ActivityId,
+                    act => act.Id,
+                    (a, act) => a
+                )
+                .AnyAsync(cancellationToken);
+
+            if (teacherOccupied)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -832,6 +1084,7 @@ public class OnlineMatchingStrategy(
         List<Slot> orderedSlots,
         HashSet<Guid> excludedSlots,
         HashSet<(Guid SlotId, Guid ResourceId)> occupiedPairs,
+        HashSet<(Guid SlotId, Guid AssignedUserId)> occupiedTeachers,
         int? weekNum,
         CancellationToken cancellationToken
     )
@@ -866,6 +1119,12 @@ public class OnlineMatchingStrategy(
                 return null;
             }
 
+            if (activity.AssignedUserId != Guid.Empty
+                && occupiedTeachers.Contains((nextSlot.Id, activity.AssignedUserId)))
+            {
+                return null;
+            }
+
             var canAssign = await _constraintEvaluator.CanAssignAsync(activity, nextSlot, resource, weekNum);
             if (!canAssign)
             {
@@ -879,6 +1138,194 @@ public class OnlineMatchingStrategy(
             }
 
             streak.Add(new SlotResourcePair(nextSlot, resource));
+            totalDuration += nextDuration;
+            currentSlot = nextSlot;
+        }
+
+        return totalDuration == requiredDuration ? streak : null;
+    }
+
+    private async Task<SlotResourcePair?> FindBestConsistentSlotResourceAsync(
+        Activity activity,
+        List<Assignment> currentAssignments,
+        List<int?> weeks,
+        Guid organizationId,
+        Guid schedulingPeriodId,
+        CancellationToken cancellationToken
+    )
+    {
+        var slots = await _dbContext
+            .Slots.IgnoreQueryFilters()
+            .Where(s => s.SchedulingPeriodId == schedulingPeriodId)
+            .Where(s => s.OrganizationId == organizationId)
+            .ToListAsync(cancellationToken);
+        var resources = await _dbContext
+            .Resources.IgnoreQueryFilters()
+            .Where(r => r.OrganizationId == organizationId)
+            .ToListAsync(cancellationToken);
+
+        var orderedAllSlots = slots
+            .OrderBy(s => s.Weekday)
+            .ThenBy(s => s.FromTime)
+            .ThenBy(s => s.ToTime)
+            .ToList();
+
+        var currentAssignmentIds = currentAssignments.Select(a => a.Id).ToHashSet();
+
+        if (!weeks.Any())
+        {
+            return null;
+        }
+ 
+        var allAssignments = (await _assignmentRepository.GetBySchedulingPeriodIdAsync(schedulingPeriodId)) ?? new List<Assignment>();
+        var activityIds = allAssignments.Select(a => a.ActivityId).Distinct().ToList();
+        var teachersMap = await _dbContext.Activities
+            .IgnoreQueryFilters()
+            .Where(a => a.OrganizationId == organizationId && activityIds.Contains(a.Id))
+            .Where(a => a.AssignedUserId != Guid.Empty)
+            .ToDictionaryAsync(a => a.Id, a => a.AssignedUserId, cancellationToken);
+ 
+        // Pre-fetch excluded slots for each week
+        var weekExcludedSlots = new Dictionary<int, HashSet<Guid>>();
+        foreach (var w in weeks)
+        {
+            weekExcludedSlots[w ?? -1] = await GetExcludedSlotsAsync(activity, organizationId, schedulingPeriodId, w);
+        }
+
+        // Try to check if the current starting slot and resource is valid for ALL weeks first
+        var startAssignment = currentAssignments.FirstOrDefault();
+        if (startAssignment != null)
+        {
+            var origSlot = slots.FirstOrDefault(s => s.Id == startAssignment.SlotId);
+            var origResource = resources.FirstOrDefault(r => r.Id == startAssignment.ResourceId);
+            if (origSlot != null && origResource != null)
+            {
+                var isOrigValidForAll = true;
+                foreach (var w in weeks)
+                {
+                    var excludedSlots = weekExcludedSlots[w ?? -1];
+                    var isValid = await IsAssignmentSetValidAsync(activity, currentAssignments.Where(a => a.WeekNum == w).ToList(), excludedSlots, w, cancellationToken);
+                    if (!isValid)
+                    {
+                        isOrigValidForAll = false;
+                        break;
+                    }
+                }
+
+                if (isOrigValidForAll)
+                {
+                    return new SlotResourcePair(origSlot, origResource);
+                }
+            }
+        }
+
+        // Search for a candidate slot & resource that works for ALL weeks
+        var candidates = new List<(SlotResourcePair Anchor, int ValidWeeksCount)>();
+        foreach (var startSlot in slots)
+        {
+            foreach (var resource in resources)
+            {
+                var streakSlots = GetStaticConsecutiveStreak(activity, startSlot, orderedAllSlots);
+                if (streakSlots == null || !streakSlots.Any()) continue;
+
+                var validWeeksCount = 0;
+                foreach (var w in weeks)
+                {
+                    var excludedSlots = weekExcludedSlots[w ?? -1];
+                    var occupiedPairs = allAssignments
+                        .Where(a => !currentAssignmentIds.Contains(a.Id))
+                        .Where(a => a.WeekNum == w || a.WeekNum == null || w == null)
+                        .Select(a => (a.SlotId, a.ResourceId))
+                        .ToHashSet();
+
+                    var occupiedTeachers = allAssignments
+                        .Where(a => !currentAssignmentIds.Contains(a.Id))
+                        .Where(a => a.WeekNum == w || a.WeekNum == null || w == null)
+                        .Where(a => teachersMap.ContainsKey(a.ActivityId))
+                        .Select(a => (a.SlotId, teachersMap[a.ActivityId]))
+                        .ToHashSet();
+
+                    var isWeekValid = true;
+                    foreach (var slot in streakSlots)
+                    {
+                        if (excludedSlots.Contains(slot.Id) || occupiedPairs.Contains((slot.Id, resource.Id)))
+                        {
+                            isWeekValid = false;
+                            break;
+                        }
+
+                        if (activity.AssignedUserId != Guid.Empty && occupiedTeachers.Contains((slot.Id, activity.AssignedUserId)))
+                        {
+                            isWeekValid = false;
+                            break;
+                        }
+
+                        var canAssign = await _constraintEvaluator.CanAssignAsync(activity, slot, resource, w);
+                        if (!canAssign)
+                        {
+                            isWeekValid = false;
+                            break;
+                        }
+                    }
+
+                    if (isWeekValid)
+                    {
+                        validWeeksCount++;
+                    }
+                }
+
+                if (validWeeksCount == weeks.Count)
+                {
+                    return new SlotResourcePair(startSlot, resource);
+                }
+                else if (validWeeksCount > 0)
+                {
+                    candidates.Add((new SlotResourcePair(startSlot, resource), validWeeksCount));
+                }
+            }
+        }
+
+        if (candidates.Any())
+        {
+            return candidates.OrderByDescending(c => c.ValidWeeksCount).First().Anchor;
+        }
+
+        return null;
+    }
+
+    private List<Slot>? GetStaticConsecutiveStreak(
+        Activity activity,
+        Slot startSlot,
+        List<Slot> orderedSlots
+    )
+    {
+        var requiredDuration = GetRequiredDuration(activity);
+        var startDuration = GetSlotDuration(startSlot);
+
+        if (requiredDuration <= TimeSpan.Zero || startDuration <= TimeSpan.Zero || startDuration > requiredDuration)
+        {
+            return null;
+        }
+
+        var streak = new List<Slot> { startSlot };
+        var currentSlot = startSlot;
+        var totalDuration = startDuration;
+
+        while (totalDuration < requiredDuration)
+        {
+            var nextSlot = orderedSlots.FirstOrDefault(s => AreConsecutive(currentSlot, s));
+            if (nextSlot == null)
+            {
+                return null;
+            }
+
+            var nextDuration = GetSlotDuration(nextSlot);
+            if (nextDuration <= TimeSpan.Zero)
+            {
+                return null;
+            }
+
+            streak.Add(nextSlot);
             totalDuration += nextDuration;
             currentSlot = nextSlot;
         }

--- a/tests/Chronos.Tests.Engine/Integration/OnlineMatchingStrategyTests.cs
+++ b/tests/Chronos.Tests.Engine/Integration/OnlineMatchingStrategyTests.cs
@@ -411,4 +411,543 @@ public class OnlineMatchingStrategyTests
         Assert.That(result.FailureReason, Does.Contain("Algorithm failed"));
         Assert.That(result.FailureReason, Does.Contain("DB connection lost"));
     }
+
+    [Test]
+    public async Task GivenActivityScope_WhenAssignmentInvalidAndRescheduled_ThenPreventsLecturerDoubleBooking()
+    {
+        var activityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var slot1Id = Guid.NewGuid();
+        var slot2Id = Guid.NewGuid();
+        var resourceId = Guid.NewGuid();
+
+        // 1. Setup the target activity
+        var activity = new Activity
+        {
+            Id = activityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = userId,
+            ActivityType = "Lecture",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(activity);
+
+        // 2. Setup another activity assigned to the same user
+        var otherActivityId = Guid.NewGuid();
+        var otherActivity = new Activity
+        {
+            Id = otherActivityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = userId,
+            ActivityType = "Lecture",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(otherActivity);
+
+        // 3. Setup two slots: Slot 1 and Slot 2
+        var slot1 = new Slot
+        {
+            Id = slot1Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(9, 0, 0),
+            ToTime = new TimeSpan(10, 0, 0),
+        };
+        var slot2 = new Slot
+        {
+            Id = slot2Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(10, 0, 0),
+            ToTime = new TimeSpan(11, 0, 0),
+        };
+        _dbContext.Slots.Add(slot1);
+        _dbContext.Slots.Add(slot2);
+
+        var resource = new Resource
+        {
+            Id = resourceId,
+            OrganizationId = _orgId,
+            ResourceTypeId = Guid.NewGuid(),
+            Location = "A",
+            Identifier = "R1",
+            Capacity = 100,
+        };
+        _dbContext.Resources.Add(resource);
+
+        // 4. Register other user's assignment at Slot 2
+        var otherAssignment = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot2Id,
+            ResourceId = resourceId,
+            ActivityId = otherActivityId,
+            WeekNum = 1,
+        };
+        _dbContext.Assignments.Add(otherAssignment);
+        await _dbContext.SaveChangesAsync();
+
+        // Target activity is currently assigned to Slot 1, but we will make it invalid
+        var currentAssignment = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot1Id,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = 1,
+        };
+
+        _assignmentRepository.GetByActivityIdAsync(activityId)
+            .Returns(new List<Assignment> { currentAssignment });
+        _assignmentRepository.GetBySchedulingPeriodIdAsync(_periodId)
+            .Returns(new List<Assignment> { currentAssignment, otherAssignment });
+
+        // Make Slot 1 invalid for the target activity using excludedSlots
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 1)
+            .Returns(new HashSet<Guid> { slot1Id });
+
+        _constraintEvaluator.CanAssignAsync(Arg.Any<Activity>(), Arg.Any<Slot>(), Arg.Any<Resource>(), Arg.Any<int?>())
+            .Returns(true);
+
+        var request = new HandleConstraintChangeRequest(
+            Guid.NewGuid(), _orgId, _periodId,
+            ConstraintScope.Activity, ConstraintChangeOperation.Updated,
+            ActivityId: activityId
+        );
+
+        // Act
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert: Rescheduling should fail because the only other slot (Slot 2) is occupied by the same lecturer
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.FailureReason, Does.Contain("could not be re-scheduled"));
+    }
+
+    [Test]
+    public async Task GivenActivityScope_WhenAssignmentRescheduled_ThenMaintainsConsistencyAcrossWeeks()
+    {
+        var activityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var slot1Id = Guid.NewGuid();
+        var slot2Id = Guid.NewGuid();
+        var resourceId = Guid.NewGuid();
+
+        var activity = new Activity
+        {
+            Id = activityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = userId,
+            ActivityType = "Lecture",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(activity);
+
+        var slot1 = new Slot
+        {
+            Id = slot1Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(9, 0, 0),
+            ToTime = new TimeSpan(10, 0, 0),
+        };
+        var slot2 = new Slot
+        {
+            Id = slot2Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(10, 0, 0),
+            ToTime = new TimeSpan(11, 0, 0),
+        };
+        _dbContext.Slots.Add(slot1);
+        _dbContext.Slots.Add(slot2);
+
+        var resource = new Resource
+        {
+            Id = resourceId,
+            OrganizationId = _orgId,
+            ResourceTypeId = Guid.NewGuid(),
+            Location = "A",
+            Identifier = "R1",
+            Capacity = 100,
+        };
+        _dbContext.Resources.Add(resource);
+        await _dbContext.SaveChangesAsync();
+
+        // The activity is assigned to Slot 1 in week 1 and week 2
+        var assignmentWeek1 = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot1Id,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = 1,
+        };
+        var assignmentWeek2 = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot1Id,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = 2,
+        };
+
+        var allAssignments = new List<Assignment> { assignmentWeek1, assignmentWeek2 };
+        _assignmentRepository.GetByActivityIdAsync(activityId).Returns(allAssignments);
+        _assignmentRepository.GetBySchedulingPeriodIdAsync(_periodId).Returns(allAssignments);
+
+        // Exclude Slot 1 for Week 1 (meaning Week 1 is invalid, but Week 2 would be valid on Slot 1)
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 1)
+            .Returns(new HashSet<Guid> { slot1Id });
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 2)
+            .Returns(new HashSet<Guid>());
+
+        _constraintEvaluator.CanAssignAsync(Arg.Any<Activity>(), Arg.Any<Slot>(), Arg.Any<Resource>(), Arg.Any<int?>())
+            .Returns(true);
+
+        var request = new HandleConstraintChangeRequest(
+            Guid.NewGuid(), _orgId, _periodId,
+            ConstraintScope.Activity, ConstraintChangeOperation.Updated,
+            ActivityId: activityId
+        );
+
+        // Act
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert: Both weeks should be rescheduled to Slot 2 (which is consistent)
+        Assert.That(result.Success, Is.True);
+        
+        // Assert that we deleted original assignments and added new ones
+        await _assignmentRepository.Received(1).DeleteAsync(assignmentWeek1);
+        await _assignmentRepository.Received(1).DeleteAsync(assignmentWeek2);
+        
+        // Assert we added two new assignments at slot2Id
+        await _assignmentRepository.Received(2).AddAsync(Arg.Is<Assignment>(a => a.SlotId == slot2Id && a.ResourceId == resourceId));
+    }
+
+    [Test]
+    public async Task GivenActivityWithTermLongConstraint_WhenWeeklyTeacherClash_ThenTriggersReschedule()
+    {
+        var activityId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var slotId = Guid.NewGuid();
+        var resourceId = Guid.NewGuid();
+
+        var activity = new Activity
+        {
+            Id = activityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = teacherId,
+            ActivityType = "Lecture",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(activity);
+
+        var slot = new Slot
+        {
+            Id = slotId,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(9, 0, 0),
+            ToTime = new TimeSpan(10, 0, 0),
+        };
+        _dbContext.Slots.Add(slot);
+
+        var resource = new Resource
+        {
+            Id = resourceId,
+            OrganizationId = _orgId,
+            ResourceTypeId = Guid.NewGuid(),
+            Location = "A",
+            Identifier = "R1",
+        };
+        _dbContext.Resources.Add(resource);
+
+        // Add a teacher weekly clash assignment in Week 1 to the database
+        var clashActivityId = Guid.NewGuid();
+        var clashActivity = new Activity
+        {
+            Id = clashActivityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = teacherId,
+            ActivityType = "Lab",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(clashActivity);
+
+        var clashAssignment = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slotId,
+            ResourceId = Guid.NewGuid(),
+            ActivityId = clashActivityId,
+            WeekNum = 1,
+        };
+        _dbContext.Assignments.Add(clashAssignment);
+        await _dbContext.SaveChangesAsync();
+
+        // The target activity has a term-long assignment (WeekNum = null) at the same slot
+        var termLongAssignment = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slotId,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = null,
+        };
+
+        var allAssignments = new List<Assignment> { termLongAssignment, clashAssignment };
+        _assignmentRepository.GetByActivityIdAsync(activityId).Returns(new List<Assignment> { termLongAssignment });
+        _assignmentRepository.GetBySchedulingPeriodIdAsync(_periodId).Returns(allAssignments);
+
+        _constraintProcessor.GetExcludedSlotIdsAsync(default, default, default, default, default)
+            .ReturnsForAnyArgs(new HashSet<Guid>());
+        _constraintEvaluator.CanAssignAsync(null!, null!, null!, default)
+            .ReturnsForAnyArgs(true);
+
+        var request = new HandleConstraintChangeRequest(
+            Guid.NewGuid(), _orgId, _periodId,
+            ConstraintScope.Activity, ConstraintChangeOperation.Updated,
+            ActivityId: activityId
+        );
+
+        // Act
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert: It should detect the teacher occupancy clash with the weekly assignment and fail/reschedule 
+        // (since only 1 slot exists, it should fail to reschedule but it should definitely not report it as still valid)
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.FailureReason, Does.Contain("could not be re-scheduled"));
+    }
+
+    [Test]
+    public async Task GivenConstraintChange_WhenFirstWeekValidButSecondWeekInvalid_ThenReschedulesBothToSameSlot()
+    {
+        var activityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var slot1Id = Guid.NewGuid();
+        var slot2Id = Guid.NewGuid();
+        var resourceId = Guid.NewGuid();
+
+        var activity = new Activity
+        {
+            Id = activityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = userId,
+            ActivityType = "Lecture",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(activity);
+
+        var slot1 = new Slot
+        {
+            Id = slot1Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(9, 0, 0),
+            ToTime = new TimeSpan(10, 0, 0),
+        };
+        var slot2 = new Slot
+        {
+            Id = slot2Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(10, 0, 0),
+            ToTime = new TimeSpan(11, 0, 0),
+        };
+        _dbContext.Slots.Add(slot1);
+        _dbContext.Slots.Add(slot2);
+
+        var resource = new Resource
+        {
+            Id = resourceId,
+            OrganizationId = _orgId,
+            ResourceTypeId = Guid.NewGuid(),
+            Location = "A",
+            Identifier = "R1",
+            Capacity = 100,
+        };
+        _dbContext.Resources.Add(resource);
+        await _dbContext.SaveChangesAsync();
+
+        // The activity is assigned to Slot 1 in week 1 and week 2
+        var assignmentWeek1 = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot1Id,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = 1,
+        };
+        var assignmentWeek2 = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot1Id,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = 2,
+        };
+
+        var allAssignments = new List<Assignment> { assignmentWeek1, assignmentWeek2 };
+        _assignmentRepository.GetByActivityIdAsync(activityId).Returns(allAssignments);
+        _assignmentRepository.GetBySchedulingPeriodIdAsync(_periodId).Returns(allAssignments);
+
+        // Exclude Slot 1 for Week 2 (meaning Week 2 is invalid on Slot 1, but Week 1 is valid on Slot 1)
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 1)
+            .Returns(new HashSet<Guid>());
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 2)
+            .Returns(new HashSet<Guid> { slot1Id });
+
+        _constraintEvaluator.CanAssignAsync(Arg.Any<Activity>(), Arg.Any<Slot>(), Arg.Any<Resource>(), Arg.Any<int?>())
+            .Returns(true);
+
+        var request = new HandleConstraintChangeRequest(
+            Guid.NewGuid(), _orgId, _periodId,
+            ConstraintScope.Activity, ConstraintChangeOperation.Updated,
+            ActivityId: activityId
+        );
+
+        // Act
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert: Both weeks should be rescheduled to Slot 2 (the consistent placement found by FindBestConsistentSlotResourceAsync)
+        Assert.That(result.Success, Is.True);
+        
+        // Assert that we deleted original assignments and added new ones
+        await _assignmentRepository.Received(1).DeleteAsync(assignmentWeek1);
+        await _assignmentRepository.Received(1).DeleteAsync(assignmentWeek2);
+        
+        // Assert we added two new assignments at slot2Id
+        await _assignmentRepository.Received(2).AddAsync(Arg.Is<Assignment>(a => a.SlotId == slot2Id && a.ResourceId == resourceId));
+    }
+
+    [Test]
+    public async Task GivenConstraintChange_WhenSomeWeeksUnassigned_ThenAssignsUnassignedWeeksToConsistentSlot()
+    {
+        var activityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var slot1Id = Guid.NewGuid();
+        var slot2Id = Guid.NewGuid();
+        var resourceId = Guid.NewGuid();
+
+        // 1. Add scheduling period to DB
+        var schedulingPeriod = new SchedulingPeriod
+        {
+            Id = _periodId,
+            OrganizationId = _orgId,
+            Name = "Semester 1",
+            FromDate = new DateTime(2026, 9, 1),
+            ToDate = new DateTime(2026, 9, 10), // 2 weeks
+        };
+        _dbContext.SchedulingPeriods.Add(schedulingPeriod);
+
+        // 2. Setup the target activity
+        var activity = new Activity
+        {
+            Id = activityId,
+            OrganizationId = _orgId,
+            SubjectId = Guid.NewGuid(),
+            AssignedUserId = userId,
+            ActivityType = "Lecture",
+            Duration = 60,
+        };
+        _dbContext.Activities.Add(activity);
+
+        var slot1 = new Slot
+        {
+            Id = slot1Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(9, 0, 0),
+            ToTime = new TimeSpan(10, 0, 0),
+        };
+        var slot2 = new Slot
+        {
+            Id = slot2Id,
+            OrganizationId = _orgId,
+            SchedulingPeriodId = _periodId,
+            Weekday = "Monday",
+            FromTime = new TimeSpan(10, 0, 0),
+            ToTime = new TimeSpan(11, 0, 0),
+        };
+        _dbContext.Slots.Add(slot1);
+        _dbContext.Slots.Add(slot2);
+
+        var resource = new Resource
+        {
+            Id = resourceId,
+            OrganizationId = _orgId,
+            ResourceTypeId = Guid.NewGuid(),
+            Location = "A",
+            Identifier = "R1",
+            Capacity = 100,
+        };
+        _dbContext.Resources.Add(resource);
+        await _dbContext.SaveChangesAsync();
+
+        // The activity is currently only assigned in Week 1 (Week 2 is unassigned/deleted)
+        var assignmentWeek1 = new Assignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            SlotId = slot1Id,
+            ResourceId = resourceId,
+            ActivityId = activityId,
+            WeekNum = 1,
+        };
+
+        var allAssignments = new List<Assignment> { assignmentWeek1 };
+        _assignmentRepository.GetByActivityIdAsync(activityId).Returns(allAssignments);
+        _assignmentRepository.GetBySchedulingPeriodIdAsync(_periodId).Returns(allAssignments);
+
+        // Exclude Slot 1 for Week 1 (meaning Week 1 is invalid on Slot 1)
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 1)
+            .Returns(new HashSet<Guid> { slot1Id });
+        _constraintProcessor.GetExcludedSlotIdsAsync(activityId, _orgId, userId, _periodId, 2)
+            .Returns(new HashSet<Guid>());
+
+        _constraintEvaluator.CanAssignAsync(Arg.Any<Activity>(), Arg.Any<Slot>(), Arg.Any<Resource>(), Arg.Any<int?>())
+            .Returns(true);
+
+        var request = new HandleConstraintChangeRequest(
+            Guid.NewGuid(), _orgId, _periodId,
+            ConstraintScope.Activity, ConstraintChangeOperation.Updated,
+            ActivityId: activityId
+        );
+
+        // Act
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert: Both weeks should be rescheduled/assigned to Slot 2
+        Assert.That(result.Success, Is.True);
+        
+        // Assert that we deleted the original Week 1 assignment
+        await _assignmentRepository.Received(1).DeleteAsync(assignmentWeek1);
+        
+        // Assert we added new assignments at slot2Id for BOTH week 1 and week 2
+        await _assignmentRepository.Received(1).AddAsync(Arg.Is<Assignment>(a => a.SlotId == slot2Id && a.ResourceId == resourceId && a.WeekNum == 1));
+        await _assignmentRepository.Received(1).AddAsync(Arg.Is<Assignment>(a => a.SlotId == slot2Id && a.ResourceId == resourceId && a.WeekNum == 2));
+    }
 }
+


### PR DESCRIPTION
Fixes bgu-nasa/main#158

- Prevents lecturer double-booking during online matching rescheduling by checking AssignedUserId availability.
- Ensures a consistent slot and resource is selected for all weeks of an activity during constraint changes.
- Properly schedules unassigned weeks during rescheduling.
- Added new integration tests validating all behavior.
